### PR TITLE
Report Tracker Update

### DIFF
--- a/src/app/api/report-tracker/route.ts
+++ b/src/app/api/report-tracker/route.ts
@@ -108,7 +108,11 @@ export async function GET() {
     const projectIds = (rows || []).map((p: any) => p.id).filter(Boolean)
     const mouIds = Array.from(new Set((rows || []).map((p: any) => p.mou_id).filter(Boolean))) as string[]
     const f5ReportedIndividualsByProject: Record<string, number> = {}
-    for (const id of projectIds) f5ReportedIndividualsByProject[id] = 0
+    const f5ReportedHouseholdsByProject: Record<string, number> = {}
+    for (const id of projectIds) {
+      f5ReportedIndividualsByProject[id] = 0
+      f5ReportedHouseholdsByProject[id] = 0
+    }
     let transferDateByProject: Record<string, string> = {}
     let rateByProject: Record<string, number> = {}
     if (mouIds.length > 0) {
@@ -137,6 +141,7 @@ export async function GET() {
     const amountsByProject: Record<string, { amount_usd: number; amount_sdg: number; f4_count: number }> = {}
     const dateByProject: Record<string, string | null> = {}
     const f5CountByProject: Record<string, number> = {}
+    const latestF5NarrativeByProject: Record<string, { challenges: string | null; lessons: string | null; recommendations: string | null }> = {}
     for (const id of projectIds) {
       amountsByProject[id] = { amount_usd: 0, amount_sdg: 0, f4_count: 0 }
       f5CountByProject[id] = 0
@@ -169,7 +174,7 @@ export async function GET() {
 
       const { data: f5Reports } = await supabase
         .from('err_program_report')
-        .select('id, project_id')
+        .select('id, project_id, report_date, negative_results, lessons_learned, suggestions')
         .in('project_id', projectIds)
       const f5ReportIds: string[] = []
       const reportToProject = new Map<string, string>()
@@ -182,17 +187,49 @@ export async function GET() {
           reportToProject.set(rid, pid)
         }
       }
+
+      /** Latest F5 report per project (by report_date, then id) for narrative fields */
+      const f5ByProject = new Map<string, any[]>()
+      for (const f5 of f5Reports || []) {
+        const pid = (f5 as any).project_id
+        if (!pid) continue
+        if (!f5ByProject.has(pid)) f5ByProject.set(pid, [])
+        f5ByProject.get(pid)!.push(f5)
+      }
+      for (const [pid, reports] of f5ByProject) {
+        const sorted = [...reports].sort((a, b) => {
+          const da = a.report_date ? new Date(a.report_date).getTime() : 0
+          const db = b.report_date ? new Date(b.report_date).getTime() : 0
+          if (db !== da) return db - da
+          const ida = String(a.id)
+          const idb = String(b.id)
+          return idb.localeCompare(ida, undefined, { numeric: true })
+        })
+        const r = sorted[0]
+        latestF5NarrativeByProject[pid] = {
+          challenges: r.negative_results != null ? String(r.negative_results) : null,
+          lessons: r.lessons_learned != null ? String(r.lessons_learned) : null,
+          recommendations: r.suggestions != null ? String(r.suggestions) : null,
+        }
+      }
+
       if (f5ReportIds.length > 0) {
         const { data: reachRows } = await supabase
           .from('err_program_reach')
-          .select('report_id, individual_count')
+          .select('report_id, individual_count, household_count')
           .in('report_id', f5ReportIds)
         for (const r of reachRows || []) {
           const reportId = (r as any).report_id
           const pid = reportId ? reportToProject.get(reportId) : null
-          const count = Number((r as any).individual_count) || 0
-          if (pid && !Number.isNaN(count)) {
-            f5ReportedIndividualsByProject[pid] = (f5ReportedIndividualsByProject[pid] ?? 0) + count
+          const ind = Number((r as any).individual_count) || 0
+          const hh = Number((r as any).household_count) || 0
+          if (pid) {
+            if (!Number.isNaN(ind)) {
+              f5ReportedIndividualsByProject[pid] = (f5ReportedIndividualsByProject[pid] ?? 0) + ind
+            }
+            if (!Number.isNaN(hh)) {
+              f5ReportedHouseholdsByProject[pid] = (f5ReportedHouseholdsByProject[pid] ?? 0) + hh
+            }
           }
         }
       }
@@ -283,6 +320,10 @@ export async function GET() {
         sector_highest_amount,
         estimated_beneficiaries: p.estimated_beneficiaries != null ? Number(p.estimated_beneficiaries) : null,
         f5_reported_individuals: f5ReportedIndividualsByProject[p.id] ?? 0,
+        f5_reported_households: f5ReportedHouseholdsByProject[p.id] ?? 0,
+        f5_challenges: latestF5NarrativeByProject[p.id]?.challenges ?? null,
+        f5_recommendations: latestF5NarrativeByProject[p.id]?.recommendations ?? null,
+        f5_lessons_learned: latestF5NarrativeByProject[p.id]?.lessons ?? null,
       }
     })
 

--- a/src/app/err-portal/report-tracker/page.tsx
+++ b/src/app/err-portal/report-tracker/page.tsx
@@ -48,6 +48,10 @@ interface ReportTrackerRow {
   sector_highest_amount?: string | null
   estimated_beneficiaries: number | null
   f5_reported_individuals: number
+  f5_reported_households: number
+  f5_challenges: string | null
+  f5_recommendations: string | null
+  f5_lessons_learned: string | null
 }
 
 function formatDate(d: string | null | undefined): string {
@@ -66,6 +70,23 @@ function formatAmount(n: number | string | null | undefined): string {
   if (Number.isNaN(num)) return '—'
   if (num === 0) return '0'
   return num.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 2 })
+}
+
+function F5TextCell({ value }: { value: string | null | undefined }) {
+  if (value == null || String(value).trim() === '') {
+    return <span className="text-muted-foreground">—</span>
+  }
+  const full = String(value)
+  const max = 120
+  const display = full.length > max ? `${full.slice(0, max)}…` : full
+  return (
+    <div
+      className="max-w-[min(100vw,220px)] text-xs text-muted-foreground line-clamp-3 whitespace-pre-wrap"
+      title={full}
+    >
+      {display}
+    </div>
+  )
 }
 
 /** Waiting 0%, Under review 25%, Partial 50%, Completed 100% (same as API). */
@@ -133,6 +154,10 @@ export default function ReportTrackerPage() {
               sector_highest_amount: r.sector_highest_amount ?? null,
               estimated_beneficiaries: r.estimated_beneficiaries != null ? Number(r.estimated_beneficiaries) : null,
               f5_reported_individuals: Number(r.f5_reported_individuals) || 0,
+              f5_reported_households: Number(r.f5_reported_households) || 0,
+              f5_challenges: r.f5_challenges ?? null,
+              f5_recommendations: r.f5_recommendations ?? null,
+              f5_lessons_learned: r.f5_lessons_learned ?? null,
             }))
           : []
       )
@@ -382,6 +407,10 @@ export default function ReportTrackerPage() {
                     { key: 'amount_sdg', header: 'SDG', format: (v) => formatAmount(v) },
                     { key: 'estimated_beneficiaries', header: 'Planned Individuals', format: (v) => (v != null && v !== '' ? Number(v).toLocaleString() : '') },
                     { key: 'f5_reported_individuals', header: 'F5 Reported Individuals', format: (v) => (v != null ? Number(v).toLocaleString() : '0') },
+                    { key: 'f5_reported_households', header: 'F5 Reported Households', format: (v) => (v != null ? Number(v).toLocaleString() : '0') },
+                    { key: 'f5_challenges', header: 'F5 Challenges' },
+                    { key: 'f5_recommendations', header: 'F5 Recommendations' },
+                    { key: 'f5_lessons_learned', header: 'F5 Lessons learned' },
                     { key: 'f4_status', header: 'F4 Status' },
                       { key: 'f5_status', header: 'F5 Status' },
                       { key: 'tracker', header: 'Tracker', format: (v) => (v != null ? Number(v).toFixed(0) : '') },
@@ -404,7 +433,7 @@ export default function ReportTrackerPage() {
               <Table>
                 <TableHeader>
                   <TableRow>
-                    {Array.from({ length: 18 }).map((_, i) => (
+                    {Array.from({ length: 22 }).map((_, i) => (
                       <TableHead key={i}>
                         <div className="h-4 w-16 rounded bg-white/20 animate-pulse" />
                       </TableHead>
@@ -414,7 +443,7 @@ export default function ReportTrackerPage() {
                 <TableBody>
                   {Array.from({ length: 10 }).map((_, r) => (
                     <TableRow key={r}>
-                      {Array.from({ length: 17 }).map((_, c) => (
+                      {Array.from({ length: 22 }).map((_, c) => (
                         <TableCell key={c}>
                           <div className="h-5 w-full max-w-[70%] rounded bg-muted animate-pulse" />
                         </TableCell>
@@ -449,6 +478,10 @@ export default function ReportTrackerPage() {
                     <TableHead className="text-center tabular-nums" dir="ltr">SDG</TableHead>
                     <TableHead className="text-center tabular-nums" dir="ltr">Planned Individuals</TableHead>
                     <TableHead className="text-center tabular-nums" dir="ltr">F5 Reported Individuals</TableHead>
+                    <TableHead className="text-center tabular-nums" dir="ltr">F5 Reported Households</TableHead>
+                    <TableHead className="text-left min-w-[200px] max-w-[240px]" dir="ltr">F5 Challenges</TableHead>
+                    <TableHead className="text-left min-w-[200px] max-w-[240px]" dir="ltr">F5 Recommendations</TableHead>
+                    <TableHead className="text-left min-w-[200px] max-w-[240px]" dir="ltr">F5 Lessons learned</TableHead>
                     <TableHead className="text-left" dir="ltr">F4 Status</TableHead>
                     <TableHead className="text-left" dir="ltr">F5 Status</TableHead>
                     <TableHead className="text-center" dir="ltr">Tracker</TableHead>
@@ -457,7 +490,7 @@ export default function ReportTrackerPage() {
                 <TableBody>
                   {paginatedRows.length === 0 ? (
                     <TableRow>
-                      <TableCell colSpan={18} className="text-muted-foreground text-center py-8">
+                      <TableCell colSpan={22} className="text-muted-foreground text-center py-8">
                         {rows.length === 0 ? 'No projects found.' : 'No rows match the selected filters.'}
                       </TableCell>
                     </TableRow>
@@ -507,6 +540,20 @@ export default function ReportTrackerPage() {
                         <TableCell className="text-center tabular-nums" dir="ltr">{formatAmount(row.amount_sdg)}</TableCell>
                         <TableCell className="text-center tabular-nums" dir="ltr">{row.estimated_beneficiaries != null ? Number(row.estimated_beneficiaries).toLocaleString() : '—'}</TableCell>
                         <TableCell className="text-center tabular-nums" dir="ltr">{row.f5_reported_individuals != null ? Number(row.f5_reported_individuals).toLocaleString() : '0'}</TableCell>
+                        <TableCell className="text-center tabular-nums" dir="ltr">
+                          {row.f5_reported_households != null
+                            ? Number(row.f5_reported_households).toLocaleString()
+                            : '0'}
+                        </TableCell>
+                        <TableCell>
+                          <F5TextCell value={row.f5_challenges} />
+                        </TableCell>
+                        <TableCell>
+                          <F5TextCell value={row.f5_recommendations} />
+                        </TableCell>
+                        <TableCell>
+                          <F5TextCell value={row.f5_lessons_learned} />
+                        </TableCell>
                         <TableCell>
                           <Select
                             value={row.f4_status}

--- a/src/app/forecast/components/ForecastDownloadModal.tsx
+++ b/src/app/forecast/components/ForecastDownloadModal.tsx
@@ -219,7 +219,8 @@ function sheetName(label: string): string {
 }
 
 function downloadCsv(filename: string, csv: string) {
-  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  // UTF-8 BOM so Excel on Windows detects UTF-8 (Arabic etc.)
+  const blob = new Blob([`\uFEFF${csv}`], { type: 'text/csv;charset=utf-8;' })
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
   a.href = url

--- a/src/lib/csvDownload.ts
+++ b/src/lib/csvDownload.ts
@@ -2,6 +2,9 @@
  * Build a CSV string from columns and rows, then trigger a file download.
  */
 
+/** UTF-8 BOM so Excel on Windows detects UTF-8 and displays Arabic correctly */
+const UTF8_BOM = '\uFEFF'
+
 function escapeCsvValue(value: string | number | null | undefined): string {
   const s = value == null ? '' : String(value)
   if (s.includes(',') || s.includes('"') || s.includes('\n') || s.includes('\r')) {
@@ -31,7 +34,7 @@ export function downloadCsv<T extends Record<string, any>>(
       })
       .join(',')
   )
-  const csv = [header, ...body].join('\r\n')
+  const csv = UTF8_BOM + [header, ...body].join('\r\n')
   const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
   const link = document.createElement('a')
   link.href = URL.createObjectURL(blob)

--- a/src/lib/downloadCsv.ts
+++ b/src/lib/downloadCsv.ts
@@ -1,3 +1,6 @@
+/** UTF-8 BOM so Excel on Windows detects UTF-8 and displays Arabic correctly */
+const UTF8_BOM = '\uFEFF'
+
 /**
  * Escape a value for CSV (quote if contains comma, newline, or double quote).
  */
@@ -34,7 +37,7 @@ export function buildCsv<T extends Record<string, unknown>>(
  * Trigger browser download of a CSV file.
  */
 export function downloadCsv(content: string, filename: string): void {
-  const blob = new Blob([content], { type: 'text/csv;charset=utf-8;' })
+  const blob = new Blob([UTF8_BOM + content], { type: 'text/csv;charset=utf-8;' })
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
   a.href = url


### PR DESCRIPTION
PR description

Summary

Improves the ERR portal experience (header / mobile menu), adds F5 data to Report Tracker (households, challenges, recommendations, lessons learned) per project, fixes stats card layout, adds UTF-8 BOM to  CSV exports for Arabic in Excel, and shows the actual server error when F1 direct upload processing fails.

### Changes

- **Report Tracker (`/api/report-tracker` + page)**  
  - Aggregates **household count** from `err_program_reach.household_count` across F5 reports linked to the project.  
  - Loads **challenges / recommendations / lessons** from `err_program_report` (mapping: `negative_results` → challenges, `suggestions` → recommendations, `lessons_learned` → lessons), using the **latest** F5 report by `report_date` then `id`.  
  - New table columns + `F5TextCell` for long text + **CSV** export updated (new columns, `colSpan`, loading skeleton).  
  - Top stats grid: `minmax(200px, 1fr)` on the first three columns to reduce column squeeze.

- **StatsDonutCard**  
  - `min-w-0` / `overflow-hidden`, title truncation, `flex-wrap` for value/donut row, legend spacing.

- **MainLayout + Sidebar**  
  - Mobile menu button in the **header** and shared **Sheet** state (`mobileSheetOpen` / `onMobileSheetOpenChange`).  
  - Hides the old fixed floating trigger when the parent controls the sheet.  
  - **Menu** icon for desktop sidebar expand/collapse; button styling updates.  
  - Optional `headerExtra` next to the language control (e.g. page explainer).

- **CSV**  
  - **UTF-8 BOM** in `src/lib/csvDownload.ts`, `src/lib/downloadCsv.ts`, and `ForecastDownloadModal` so Excel on Windows opens Arabic text correctly.

- **F1 Direct upload**  
  - On `POST /api/fsystem/process` failure, the alert shows `error.message` (server message) when available, instead of only a generic “try again” message.

### Testing

- [ ] **Report Tracker:** Load with projects that have F5 data; confirm new columns (numbers and text) and horizontal scroll.  
- [ ] **Report Tracker → Download CSV:** Open in **Excel (Windows)** and confirm Arabic and new columns render correctly.  
- [ ] **Narrow viewport:** Confirm stats cards (F4/F5/Tracker + side cards) do not break.  
- [ ] **Mobile:** Header menu opens/closes the sheet; **Desktop:** sidebar toggle still works.  
- [ ] **F1 direct upload** (with/without `OPENAI_API_KEY`): Confirm a clear error on 500.  
- [ ] **Dashboard / Project management CSV** (if used): Arabic opens correctly in Excel.  
- [ ] **Forecast CSV** (if used): Same BOM check.

### Risks

- **Response size / performance:** `GET /api/report-tracker` returns longer text and extra F5 queries; JSON may grow on very large project lists.  
- **“Latest F5” semantics:** Latest by `report_date` may be ambiguous if multiple reports share the same day (ties broken by `id`); document for users if needed.  
- **BOM in CSV:** Rare tools may show a stray character at the start of the first cell; standard for Excel + UTF-8.  
- **RLS / Supabase:** If `err_program_report` or `err_program_reach` is blocked by policies, new columns may stay empty in some environments.

### Notes

- **Challenges / recommendations / lessons** come from **F5** `err_program_report` columns as mapped above, not custom Arabic column names in the database.  
- **Household count** is from **F5** reach data (`err_program_reach`), not F1 `planned_activities`.  
- Before merging, run `git diff --stat` locally and align the file list with this PR.

**Likely files in this PR**  
`src/app/api/report-tracker/route.ts` · `src/app/err-portal/report-tracker/page.tsx` · `src/components/report-tracker-stats/StatsDonutCard.tsx` · `src/components/layout/MainLayout.tsx` · `src/components/layout/Sidebar.tsx` · `src/lib/csvDownload.ts` · `src/lib/downloadCsv.ts` · `src/app/forecast/components/ForecastDownloadModal.tsx` · `src/app/err-portal/f1-work-plans/components/DirectUpload/index.tsx` — adjust to match your actual diff.

------------------------------------------------------------------------------------------------------------------------------------------

- API: aggregate F5 household_count from err_program_reach; expose latest F5 report narrative per project (negative_results → challenges, suggestions → recommendations, lessons_learned) from err_program_report ordered by report_date.
- UI: new columns for F5 households, challenges, recommendations, lessons learned; F5TextCell for long text; CSV export includes new fields; table colSpan/skeleton column count updated; UTF-8 BOM on CSV for Excel/Arabic. Stats & layout
- StatsDonutCard: min-width/overflow, header truncation, flex-wrap for donut row; report tracker grid uses minmax(200px,1fr) for first three columns to avoid squeezed cards. Portal header
- MainLayout: mobile menu button in sticky header; shared mobile sheet state with Sidebar; desktop sidebar toggle uses Menu icon; styling iterations (hamburger on brand background / transparent desktop toggle per iteration). Sidebar
- Optional mobileSheetOpen / onMobileSheetOpenChange; hide fixed floating trigger when header controls the sheet. F1 Direct upload
- On process failure, surface server error message in alert instead of generic "try again in a minute" only. CSV
- Prepend UTF-8 BOM in csvDownload.ts, downloadCsv.ts, and Forecast download modal so Excel on Windows opens Arabic correctly.