### PR TITLE
Visual Compliance (OFAC/Descartes) screening for F1 payments

### DIFF
--- a/scripts/import-approved-beneficiaries.js
+++ b/scripts/import-approved-beneficiaries.js
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+/**
+ * One-time import of the pre-approved beneficiary list (previously screened
+ * and approved by the compliance officer) into the approved_beneficiaries
+ * whitelist. Names on this list auto-approve during F1 compliance screening.
+ *
+ * Usage: node scripts/import-approved-beneficiaries.js <path-to-list.csv>
+ *
+ * Input: CSV with a "name" column, or a plain text file with one name per line.
+ * Requires SUPABASE_SERVICE_ROLE_KEY (or anon key) in .env.local.
+ */
+
+const { createClient } = require('@supabase/supabase-js')
+const fs = require('fs')
+const path = require('path')
+
+function loadEnvFile() {
+  const envPath = path.join(__dirname, '..', '.env.local')
+  if (!fs.existsSync(envPath)) {
+    console.error('Error: .env.local file not found')
+    process.exit(1)
+  }
+  const env = {}
+  fs.readFileSync(envPath, 'utf-8').split('\n').forEach(line => {
+    const trimmed = line.trim()
+    if (trimmed && !trimmed.startsWith('#')) {
+      const [key, ...valueParts] = trimmed.split('=')
+      if (key && valueParts.length > 0) {
+        env[key.trim()] = valueParts.join('=').trim().replace(/^['"]|['"]$/g, '')
+      }
+    }
+  })
+  return env
+}
+
+// Must stay in sync with nameTokens/normalizedNameKey in src/lib/compliance.ts
+const STOP_WORDS = new Set([
+  'bin', 'ibn', 'mr', 'mrs', 'dr', 'the', 'of', 'for',
+  'name', 'account', 'number', 'bank', 'signature'
+])
+
+function nameTokens(name) {
+  const cleaned = (name || '').toLowerCase().replace(/[^a-z\u0600-\u06ff\s]/g, ' ')
+  return cleaned
+    .split(/\s+/)
+    .filter(w => w.length > 1 && !STOP_WORDS.has(w) && !/^\d+$/.test(w))
+}
+
+function normalizedNameKey(name) {
+  const counts = new Map()
+  for (const tok of nameTokens(name)) {
+    counts.set(tok, (counts.get(tok) || 0) + 1)
+  }
+  return Array.from(counts.entries())
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([tok, n]) => `${tok}:${n}`)
+    .join('|')
+}
+
+function parseNames(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf-8')
+  const lines = raw.split(/\r?\n/).map(l => l.trim()).filter(Boolean)
+  if (lines.length === 0) return []
+
+  // CSV with header: find the "name" column
+  const header = lines[0].split(',').map(h => h.trim().toLowerCase().replace(/^["']|["']$/g, ''))
+  const nameIdx = header.indexOf('name')
+  if (nameIdx >= 0) {
+    return lines.slice(1).map(line => {
+      // naive CSV split is fine for single-column-name lists; quoted commas in
+      // names are not expected in this data
+      const cols = line.split(',')
+      return (cols[nameIdx] || '').trim().replace(/^["']|["']$/g, '')
+    }).filter(Boolean)
+  }
+
+  // Plain list: one name per line
+  return lines
+}
+
+async function main() {
+  const inputPath = process.argv[2]
+  if (!inputPath) {
+    console.error('Usage: node scripts/import-approved-beneficiaries.js <path-to-list.csv>')
+    process.exit(1)
+  }
+  if (!fs.existsSync(inputPath)) {
+    console.error(`Error: file not found: ${inputPath}`)
+    process.exit(1)
+  }
+
+  const env = loadEnvFile()
+  const supabaseUrl = env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseKey = env.SUPABASE_SERVICE_ROLE_KEY || env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  if (!supabaseUrl || !supabaseKey) {
+    console.error('Error: missing NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY in .env.local')
+    process.exit(1)
+  }
+  const supabase = createClient(supabaseUrl, supabaseKey)
+
+  const names = parseNames(inputPath)
+  console.log(`Read ${names.length} name(s) from ${inputPath}`)
+
+  const byKey = new Map()
+  let skipped = 0
+  for (const name of names) {
+    const key = normalizedNameKey(name)
+    if (!key || nameTokens(name).length < 2) {
+      console.warn(`  Skipping (needs at least 2 name words): "${name}"`)
+      skipped++
+      continue
+    }
+    if (!byKey.has(key)) byKey.set(key, name)
+  }
+
+  const rows = Array.from(byKey.entries()).map(([normalized_key, name]) => ({
+    name,
+    normalized_key,
+    source: 'import'
+  }))
+
+  console.log(`Importing ${rows.length} unique name(s) (${skipped} skipped)...`)
+
+  let imported = 0
+  for (let i = 0; i < rows.length; i += 200) {
+    const chunk = rows.slice(i, i + 200)
+    const { error } = await supabase
+      .from('approved_beneficiaries')
+      .upsert(chunk, { onConflict: 'normalized_key', ignoreDuplicates: true })
+    if (error) {
+      console.error('Import error:', error.message)
+      process.exit(1)
+    }
+    imported += chunk.length
+  }
+
+  console.log(`Done. ${imported} name(s) in the approved beneficiaries whitelist.`)
+  console.log('These payees will now auto-approve during F1 compliance screening.')
+}
+
+main()

--- a/scripts/import-cleared-names.js
+++ b/scripts/import-cleared-names.js
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+
+/**
+ * Import a compliance-officer "cleared names" list (English + Arabic) into the
+ * approved_beneficiaries exception list, and reconcile it against the banking
+ * details stored in err_projects so already-flagged/pending F1s for these
+ * beneficiaries are cleared.
+ *
+ * Input: .xlsx with two columns of names, e.g. "Name ENG" and "Name AR"
+ * (falls back to the first two columns if those headers are absent).
+ *
+ * Usage:
+ *   node scripts/import-cleared-names.js <file.xlsx>            # dry run (no writes)
+ *   node scripts/import-cleared-names.js <file.xlsx> --commit   # write whitelist + clear exact matches
+ *   node scripts/import-cleared-names.js <file.xlsx> --commit --fuzzy
+ *        # also clear high-confidence subset matches (DB name tokens ⊆ a cleared full name, >=3 shared tokens)
+ *
+ * Requires NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY in .env.local.
+ */
+
+const { createClient } = require('@supabase/supabase-js')
+const XLSX = require('xlsx')
+const fs = require('fs')
+const path = require('path')
+
+function loadEnvFile() {
+  const envPath = path.join(__dirname, '..', '.env.local')
+  if (!fs.existsSync(envPath)) {
+    console.error('Error: .env.local file not found')
+    process.exit(1)
+  }
+  const env = {}
+  fs.readFileSync(envPath, 'utf-8').split('\n').forEach(line => {
+    const trimmed = line.trim()
+    if (trimmed && !trimmed.startsWith('#')) {
+      const [key, ...valueParts] = trimmed.split('=')
+      if (key && valueParts.length > 0) {
+        env[key.trim()] = valueParts.join('=').trim().replace(/^['"]|['"]$/g, '')
+      }
+    }
+  })
+  return env
+}
+
+// --- Name normalization (kept in sync with src/lib/compliance.ts) ---
+const STOP_WORDS = new Set([
+  'bin', 'ibn', 'mr', 'mrs', 'dr', 'the', 'of', 'for',
+  'name', 'account', 'number', 'bank', 'signature'
+])
+
+function nameTokens(name) {
+  const cleaned = (name || '').toLowerCase().replace(/[^a-z\u0600-\u06ff\s]/g, ' ')
+  return cleaned
+    .split(/\s+/)
+    .filter(w => w.length > 1 && !STOP_WORDS.has(w) && !/^\d+$/.test(w))
+}
+
+function normalizedNameKey(name) {
+  const counts = new Map()
+  for (const tok of nameTokens(name)) counts.set(tok, (counts.get(tok) || 0) + 1)
+  return Array.from(counts.entries())
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([tok, n]) => `${tok}:${n}`)
+    .join('|')
+}
+
+// Mirror of extractNamesFromBanking in src/lib/compliance.ts
+function extractNamesFromBanking(text) {
+  if (!text) return []
+  const names = new Set()
+  const nameLineRe = /(?:^|\n)\s*Name\s*:\s*([^\n]+)/gi
+  let m
+  while ((m = nameLineRe.exec(text)) !== null) {
+    const candidate = m[1].trim()
+    if (candidate.length > 2) names.add(candidate)
+  }
+  const bankKeywordRe = /bank|account|number|iban|signature|date\s*:|بنك/i
+  const lines = text.split('\n').map(l => l.trim()).filter(Boolean).slice(0, 4)
+  for (const line of lines) {
+    if (bankKeywordRe.test(line) || /^\d+$/.test(line.replace(/\s/g, ''))) continue
+    if (line.length >= 6 && line.length < 100 && line.split(/\s+/).length >= 2) {
+      names.add(line.replace(/^(the works of)\s+/i, ''))
+    }
+  }
+  const byKey = new Map()
+  for (const candidate of names) {
+    if (nameTokens(candidate).length < 2) continue
+    const key = normalizedNameKey(candidate)
+    const cleaned = candidate.replace(/^\s*Name\s*:\s*/i, '').trim()
+    const existing = byKey.get(key)
+    if (!existing || cleaned.length < existing.length) byKey.set(key, cleaned)
+  }
+  return Array.from(byKey.values())
+}
+
+function readClearedNames(xlsxPath) {
+  const wb = XLSX.readFile(xlsxPath)
+  const ws = wb.Sheets[wb.SheetNames[0]]
+  const rows = XLSX.utils.sheet_to_json(ws, { header: 1, defval: '' })
+  if (rows.length === 0) return []
+  const header = rows[0].map(h => (h || '').toString().trim().toLowerCase())
+  let engIdx = header.findIndex(h => h.includes('eng'))
+  let arIdx = header.findIndex(h => h.includes('ar'))
+  let body = rows.slice(1)
+  if (engIdx === -1 && arIdx === -1) {
+    // No recognizable header — treat first two columns as eng, ar
+    engIdx = 0
+    arIdx = 1
+    body = rows
+  } else {
+    if (engIdx === -1) engIdx = arIdx === 0 ? 1 : 0
+    if (arIdx === -1) arIdx = engIdx === 0 ? 1 : 0
+  }
+  return body
+    .map(r => ({
+      eng: (r[engIdx] || '').toString().trim(),
+      ar: (r[arIdx] || '').toString().trim()
+    }))
+    .filter(x => x.eng || x.ar)
+}
+
+async function main() {
+  const inputPath = process.argv[2]
+  const commit = process.argv.includes('--commit')
+  const fuzzy = process.argv.includes('--fuzzy')
+  if (!inputPath) {
+    console.error('Usage: node scripts/import-cleared-names.js <file.xlsx> [--commit] [--fuzzy]')
+    process.exit(1)
+  }
+  if (!fs.existsSync(inputPath)) {
+    console.error(`Error: file not found: ${inputPath}`)
+    process.exit(1)
+  }
+
+  const env = loadEnvFile()
+  const supabaseUrl = env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseKey = env.SUPABASE_SERVICE_ROLE_KEY || env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  if (!supabaseUrl || !supabaseKey) {
+    console.error('Error: missing NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY in .env.local')
+    process.exit(1)
+  }
+  const supabase = createClient(supabaseUrl, supabaseKey)
+
+  console.log(`\nMode: ${commit ? 'COMMIT (writes enabled)' : 'DRY RUN (no writes)'}${fuzzy ? ' + FUZZY subset clearing' : ''}\n`)
+
+  // 1) Parse cleared names ----------------------------------------------------
+  const cleared = readClearedNames(inputPath)
+  const whitelistByKey = new Map() // normalized_key -> display name
+  const clearedTokenSets = [] // { key, tokens:Set<string>, display } for subset matching (english + arabic)
+  for (const { eng, ar } of cleared) {
+    for (const name of [eng, ar]) {
+      if (!name) continue
+      const toks = nameTokens(name)
+      if (toks.length < 2) continue
+      const key = normalizedNameKey(name)
+      if (!whitelistByKey.has(key)) whitelistByKey.set(key, name)
+      clearedTokenSets.push({ key, tokens: new Set(toks), display: name })
+    }
+  }
+  const clearedKeys = new Set(whitelistByKey.keys())
+  console.log(`Cleared list: ${cleared.length} rows → ${clearedKeys.size} unique name keys (EN+AR)`) 
+
+  // 2) Import into approved_beneficiaries -------------------------------------
+  const rows = Array.from(whitelistByKey.entries()).map(([normalized_key, name]) => ({
+    name,
+    normalized_key,
+    source: 'import'
+  }))
+  if (commit) {
+    let imported = 0
+    for (let i = 0; i < rows.length; i += 200) {
+      const chunk = rows.slice(i, i + 200)
+      const { error } = await supabase
+        .from('approved_beneficiaries')
+        .upsert(chunk, { onConflict: 'normalized_key', ignoreDuplicates: true })
+      if (error) {
+        console.error('Whitelist import error:', error.message)
+        process.exit(1)
+      }
+      imported += chunk.length
+    }
+    console.log(`Whitelist: upserted ${imported} name key(s) into approved_beneficiaries.`)
+  } else {
+    console.log(`Whitelist: would upsert ${rows.length} name key(s) into approved_beneficiaries.`)
+  }
+
+  // 3) Reconcile against banking details stored in err_projects ---------------
+  // Pull screenings + the banking_details from the relevant table (err_projects).
+  const { data: screenings, error: scErr } = await supabase
+    .from('compliance_screenings')
+    .select('id, project_id, names, status, flag_type, finance_review_status')
+  if (scErr) throw scErr
+
+  const projIds = screenings.map(s => s.project_id)
+  const bankById = new Map()
+  for (let i = 0; i < projIds.length; i += 200) {
+    const chunk = projIds.slice(i, i + 200)
+    const { data: proj, error: pErr } = await supabase
+      .from('err_projects')
+      .select('id, banking_details')
+      .in('id', chunk)
+    if (pErr) throw pErr
+    for (const p of proj || []) bankById.set(p.id, p.banking_details || '')
+  }
+
+  const subsetMatch = (extractedNames) => {
+    // Every extracted name must be a >=3-token subset of some cleared full name
+    if (!extractedNames.length) return null
+    const evidence = []
+    for (const nm of extractedNames) {
+      const toks = new Set(nameTokens(nm))
+      if (toks.size < 3) return null
+      const hit = clearedTokenSets.find(c =>
+        c.tokens.size >= toks.size &&
+        Array.from(toks).every(t => c.tokens.has(t))
+      )
+      if (!hit) return null
+      evidence.push({ dbName: nm, clearedName: hit.display })
+    }
+    return evidence
+  }
+
+  const exactHits = []
+  const fuzzyHits = []
+  for (const s of screenings) {
+    // Prefer freshly extracting from the live banking details (relevant table)
+    const banking = bankById.get(s.project_id) || ''
+    const extracted = extractNamesFromBanking(banking)
+    const names = extracted.length ? extracted : (Array.isArray(s.names) ? s.names : [])
+    if (!names.length) continue
+    const keys = names.map(normalizedNameKey)
+    const exact = keys.length > 0 && keys.every(k => clearedKeys.has(k))
+    if (exact) {
+      exactHits.push({ s, names, banking })
+      continue
+    }
+    const ev = subsetMatch(names)
+    if (ev) fuzzyHits.push({ s, names, banking, evidence: ev })
+  }
+
+  const summarize = (label, hits) => {
+    console.log(`\n${label}: ${hits.length}`)
+    for (const h of hits.slice(0, 40)) {
+      const st = h.s.status + (h.s.flag_type ? `/${h.s.flag_type}` : '')
+      console.log(`  - project ${h.s.project_id} [${st}]`)
+      console.log(`      names: ${JSON.stringify(h.names)}`)
+      console.log(`      bank : ${JSON.stringify((h.banking || '').replace(/\n/g, ' | ').slice(0, 140))}`)
+      if (h.evidence) {
+        for (const e of h.evidence) console.log(`      match: "${e.dbName}" ⊆ cleared "${e.clearedName}"`)
+      }
+    }
+    if (hits.length > 40) console.log(`  ... and ${hits.length - 40} more`)
+  }
+  summarize('Exact name matches (all payee names on cleared list)', exactHits)
+  if (fuzzy) summarize('Fuzzy subset matches (>=3 shared tokens)', fuzzyHits)
+  else console.log(`\nFuzzy subset candidates (not applied; pass --fuzzy to clear): ${fuzzyHits.length}`)
+
+  // 4) Clear matched screenings -----------------------------------------------
+  // Safety: a typed sanctions_match is only ever cleared on an EXACT full-name
+  // match, never on a fuzzy subset match — those stay for manual review.
+  const safeFuzzy = fuzzyHits.filter(h => {
+    if (h.s.flag_type === 'sanctions_match') {
+      console.warn(`\n  SKIP fuzzy-clear of sanctions_match ${h.s.project_id} — needs manual review.`)
+      return false
+    }
+    return true
+  })
+  const toClear = fuzzy ? [...exactHits, ...safeFuzzy] : exactHits
+  const clearable = toClear.filter(h => h.s.status !== 'auto_approved' && h.s.status !== 'cleared')
+  if (clearable.length === 0) {
+    console.log('\nNo screenings need clearing.')
+  } else if (commit) {
+    let cleared = 0
+    for (const h of clearable) {
+      const { error } = await supabase
+        .from('compliance_screenings')
+        .update({
+          status: 'auto_approved',
+          flag_note: 'Cleared via compliance-officer cleared-names list import',
+          screened_at: new Date().toISOString(),
+          finance_review_status: null,
+          finance_review_note: null
+        })
+        .eq('id', h.s.id)
+      if (error) {
+        console.error(`  Failed to clear ${h.s.project_id}:`, error.message)
+        continue
+      }
+      cleared++
+    }
+    console.log(`\nCleared ${cleared} screening(s) → status auto_approved (payments unblocked).`)
+  } else {
+    console.log(`\nWould clear ${clearable.length} screening(s) (run with --commit).`)
+  }
+
+  console.log('\nDone.')
+}
+
+main().catch(e => { console.error(e); process.exit(1) })

--- a/scripts/screen-sanctions-strict.py
+++ b/scripts/screen-sanctions-strict.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Strict sanctions screen: full legal name (exact token multiset) + optional DOB pattern.
+
+Requires: /tmp/sanctions/sdn.xml and uk-conlist.csv (OFAC + UK OFSI).
+Run from repo root: python3 scripts/screen-sanctions-strict.py
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import re
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from collections import Counter, defaultdict
+
+SANCTIONS_DIR = "/tmp/sanctions"
+OUTPUT = os.path.join(os.path.dirname(__file__), "output", "sanctions-strict-screen.json")
+
+STOP = {"bin", "ibn", "mr", "mrs", "dr", "the", "of", "for", "name", "account", "number", "bank", "signature"}
+MONTHS = {m: i for i, m in enumerate(["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"], 1)}
+
+
+def load_env() -> dict[str, str]:
+    env: dict[str, str] = {}
+    with open(".env.local", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                k, v = line.split("=", 1)
+                env[k.strip()] = v.strip().strip("'\"")
+    return env
+
+
+def tokens(name: str) -> list[str]:
+    s = re.sub(r"[^a-z\u0600-\u06ff\s]", " ", (name or "").lower())
+    return [w for w in s.split() if len(w) > 1 and w not in STOP and not w.isdigit()]
+
+
+def multiset_key(name: str) -> tuple[tuple[str, int], ...]:
+    return tuple(sorted(Counter(tokens(name)).items()))
+
+
+def full_legal_name_match(a: str, b: str) -> bool:
+    return multiset_key(a) == multiset_key(b) and sum(Counter(tokens(a)).values()) >= 2
+
+
+def parse_date(raw: str) -> dict | None:
+    s = raw.strip()
+    m = re.match(r"^(\d{2})/(\d{2})/(\d{4})$", s)
+    if m:
+        d, mo, y = map(int, m.groups())
+        return {"day": d or None, "month": mo or None, "year": y, "raw": s}
+    m = re.match(r"^(\d{1,2})[/.-](\d{1,2})[/.-](\d{2,4})$", s)
+    if m:
+        d, mo, y = int(m[1]), int(m[2]), int(m[3])
+        if y < 100:
+            y += 1900 if y > 30 else 2000
+        return {"day": d, "month": mo, "year": y, "raw": s}
+    m = re.match(r"^(\d{4})[/.-](\d{1,2})[/.-](\d{1,2})$", s)
+    if m:
+        y, mo, d = map(int, m.groups())
+        return {"day": d, "month": mo, "year": y, "raw": s}
+    m = re.match(r"^(\d{1,2})\s+([A-Za-z]+)\s+(\d{4})$", s)
+    if m:
+        mon = MONTHS.get(m[2].lower()[:3])
+        if mon:
+            return {"day": int(m[1]), "month": mon, "year": int(m[3]), "raw": s}
+    return None
+
+
+def date_match_type(a: dict, b: dict) -> str | None:
+    if a.get("day") and b.get("day") and a.get("month") and b.get("month") and a.get("year") and b.get("year"):
+        if a["day"] == b["day"] and a["month"] == b["month"] and a["year"] == b["year"]:
+            return "full"
+    if a.get("month") and b.get("month") and a.get("year") and b.get("year"):
+        if a["month"] == b["month"] and a["year"] == b["year"]:
+            return "month_year"
+    if a.get("day") and b.get("day") and a.get("month") and b.get("month"):
+        if a["day"] == b["day"] and a["month"] == b["month"]:
+            return "day_month"
+    return None
+
+
+def extract_dates(text: str) -> list[dict]:
+    found: list[dict] = []
+    for m in re.finditer(r"\b\d{1,2}[/.-]\d{1,2}[/.-]\d{2,4}\b|\b\d{4}[/.-]\d{1,2}[/.-]\d{1,2}\b", text):
+        p = parse_date(m.group())
+        if p:
+            found.append(p)
+    seen: set[tuple] = set()
+    out: list[dict] = []
+    for d in found:
+        k = (d.get("day"), d.get("month"), d.get("year"))
+        if k not in seen:
+            seen.add(k)
+            out.append(d)
+    return out
+
+
+def extract_names_banking(text: str) -> list[str]:
+    if not text:
+        return []
+    names: set[str] = set()
+    for m in re.finditer(r"(?:^|\n)\s*Name\s*:\s*([^\n]+)", text, re.I):
+        if len(m.group(1).strip()) > 2:
+            names.add(m.group(1).strip())
+    bank_kw = re.compile(r"bank|account|number|iban|signature|date\s*:|بنك", re.I)
+    for line in [l.strip() for l in text.split("\n") if l.strip()][:4]:
+        if bank_kw.search(line) or re.sub(r"\s", "", line).isdigit():
+            continue
+        if 6 <= len(line) < 100 and len(line.split()) >= 2:
+            names.add(re.sub(r"^(the works of)\s+", "", line, flags=re.I))
+    return list(names)
+
+
+def sb_get(env: dict[str, str], table: str, select: str) -> list[dict]:
+    key = env.get("SUPABASE_SERVICE_ROLE_KEY") or env["NEXT_PUBLIC_SUPABASE_ANON_KEY"]
+    url = f"{env['NEXT_PUBLIC_SUPABASE_URL']}/rest/v1/{table}?select={urllib.parse.quote(select)}"
+    headers = {"apikey": env["NEXT_PUBLIC_SUPABASE_ANON_KEY"], "Authorization": f"Bearer {key}"}
+    all_rows: list[dict] = []
+    start = 0
+    while True:
+        req = urllib.request.Request(url, headers={**headers, "Range": f"{start}-{start + 999}"})
+        with urllib.request.urlopen(req) as r:
+            chunk = json.loads(r.read())
+        if not chunk:
+            break
+        all_rows.extend(chunk)
+        if len(chunk) < 1000:
+            break
+        start += 1000
+    return all_rows
+
+
+def load_sanctions() -> list[dict]:
+    ns = "{https://sanctionslistservice.ofac.treas.gov/api/PublicationPreview/exports/XML}"
+    root = ET.parse(os.path.join(SANCTIONS_DIR, "sdn.xml")).getroot()
+    out: list[dict] = []
+    for entry in root.findall(f".//{ns}sdnEntry"):
+        st = entry.find(f"{ns}sdnType")
+        if st is None or st.text != "Individual":
+            continue
+        fe, le = entry.find(f"{ns}firstName"), entry.find(f"{ns}lastName")
+        first = (fe.text or "").strip() if fe is not None else ""
+        last = (le.text or "").strip() if le is not None else ""
+        display = f"{first} {last}".strip() or last
+        dates: list[dict] = []
+        dlist = entry.find(f"{ns}dateOfBirthList")
+        if dlist is not None:
+            for item in dlist.findall(f"{ns}dateOfBirthItem"):
+                dob = item.find(f"{ns}dateOfBirth")
+                if dob is not None and dob.text:
+                    p = parse_date(dob.text.strip())
+                    if p:
+                        dates.append(p)
+        program = None
+        prog_el = entry.find(f"{ns}programList")
+        if prog_el is not None:
+            pe = prog_el.find(f"{ns}program")
+            if pe is not None:
+                program = pe.text
+        out.append(
+            {
+                "name": display,
+                "display": f"{last}, {first}".strip(", "),
+                "mkey": multiset_key(display),
+                "dates": dates,
+                "list": "OFAC",
+                "program": program,
+            }
+        )
+
+    with open(os.path.join(SANCTIONS_DIR, "uk-conlist.csv"), encoding="utf-8", errors="replace") as f:
+        reader = csv.DictReader(f.readlines()[1:])
+        for row in reader:
+            parts = [(row.get(k) or "").strip() for k in ["Name 6", "Name 1", "Name 2", "Name 3"] if (row.get(k) or "").strip()]
+            if len(parts) < 2:
+                continue
+            display = " ".join(parts)
+            dates: list[dict] = []
+            dob = (row.get("DOB") or "").strip()
+            if dob:
+                p = parse_date(dob)
+                if p:
+                    dates.append(p)
+            out.append(
+                {
+                    "name": display,
+                    "display": display,
+                    "mkey": multiset_key(display),
+                    "dates": dates,
+                    "list": "UK",
+                    "program": row.get("Regime"),
+                }
+            )
+    return out
+
+
+def main() -> None:
+    env = load_env()
+    sanctions = load_sanctions()
+    by_mkey: dict[tuple, list[dict]] = defaultdict(list)
+    by_set: dict[frozenset, list[dict]] = defaultdict(list)
+    for s in sanctions:
+        if s["mkey"]:
+            by_mkey[s["mkey"]].append(s)
+            by_set[frozenset(t for t, _ in s["mkey"])].append(s)
+
+    portal: list[dict] = []
+    for p in sb_get(env, "err_projects", "id,banking_details,intended_beneficiaries"):
+        if p.get("banking_details"):
+            for name in extract_names_banking(p["banking_details"]):
+                if sum(Counter(tokens(name)).values()) < 2:
+                    continue
+                portal.append(
+                    {
+                        "name": name,
+                        "mkey": multiset_key(name),
+                        "dates": extract_dates(p["banking_details"]),
+                        "source": "banking",
+                        "id": p["id"],
+                    }
+                )
+    for m in sb_get(env, "mous", "id,partner_name,banking_details_override"):
+        if m.get("partner_name") and sum(Counter(tokens(m["partner_name"])).values()) >= 2:
+            portal.append(
+                {
+                    "name": m["partner_name"],
+                    "mkey": multiset_key(m["partner_name"]),
+                    "dates": [],
+                    "source": "mou_partner",
+                    "id": m["id"],
+                }
+            )
+        if m.get("banking_details_override"):
+            for name in extract_names_banking(m["banking_details_override"]):
+                if sum(Counter(tokens(name)).values()) < 2:
+                    continue
+                portal.append(
+                    {
+                        "name": name,
+                        "mkey": multiset_key(name),
+                        "dates": extract_dates(m["banking_details_override"]),
+                        "source": "mou_banking",
+                        "id": m["id"],
+                    }
+                )
+
+    name_hits: list[dict] = []
+    date_hits: list[dict] = []
+    weak_set_hits: list[dict] = []
+
+    for p in portal:
+        pset = frozenset(t for t, _ in p["mkey"])
+        for s in by_set.get(pset, []):
+            if not full_legal_name_match(p["name"], s["name"]):
+                if len(pset) >= 2:
+                    weak_set_hits.append({"portal": p, "sanction": s})
+                continue
+            best = None
+            for pd in p["dates"]:
+                for sd in s["dates"]:
+                    t = date_match_type(pd, sd)
+                    if t:
+                        rank = {"full": 3, "month_year": 2, "day_month": 1}
+                        if not best or rank[t] > rank[best[0]]:
+                            best = (t, pd, sd)
+            rec = {"portal": p, "sanction": s, "date_match": best}
+            if best:
+                date_hits.append(rec)
+            else:
+                name_hits.append(rec)
+
+    os.makedirs(os.path.dirname(OUTPUT), exist_ok=True)
+    report = {
+        "strict_full_legal_name_only": name_hits,
+        "strict_full_legal_name_with_date": date_hits,
+        "weak_same_token_set": weak_set_hits[:50],
+        "stats": {
+            "portal_unique_names": len({p["mkey"] for p in portal}),
+            "portal_with_dates_in_banking": sum(1 for p in portal if p["dates"]),
+            "sanction_entries": len(sanctions),
+        },
+    }
+    with open(OUTPUT, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2, default=str)
+
+    print("Strict full legal name + date screen")
+    print(f"  Portal unique payee names: {report['stats']['portal_unique_names']}")
+    print(f"  Portal banking texts with dates: {report['stats']['portal_with_dates_in_banking']}")
+    print(f"  Full name + date pattern: {len(date_hits)}")
+    print(f"  Full name only: {len(name_hits)}")
+    print(f"  Weak (same words, different count): {len(weak_set_hits)}")
+    print(f"  Report: {OUTPUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sql/add_compliance_flag_types.sql
+++ b/sql/add_compliance_flag_types.sql
@@ -1,0 +1,19 @@
+-- Extend compliance screening for typed flags from demo feedback:
+-- 1) missing_id — Ahmed flags missing ID; finance uploads ID or dismisses erroneous flag
+-- 2) sanctions_match — potential Descartes/OFAC match; payment stopped until dismissed
+
+ALTER TABLE compliance_screenings
+  ADD COLUMN IF NOT EXISTS flag_type TEXT
+    CHECK (flag_type IS NULL OR flag_type IN ('missing_id', 'sanctions_match'));
+
+ALTER TABLE compliance_screenings
+  ADD COLUMN IF NOT EXISTS alerted_at TIMESTAMPTZ;
+
+-- Identity / national ID document attached to the F1 after finance uploads it
+ALTER TABLE err_projects
+  ADD COLUMN IF NOT EXISTS identity_document_file_key TEXT;
+
+COMMENT ON COLUMN compliance_screenings.flag_type IS
+  'missing_id = F1 missing ID document; sanctions_match = potential Descartes/OFAC list match';
+COMMENT ON COLUMN err_projects.identity_document_file_key IS
+  'Storage path for beneficiary ID document uploaded during compliance finance review';

--- a/sql/create_compliance_screenings.sql
+++ b/sql/create_compliance_screenings.sql
@@ -1,0 +1,53 @@
+-- Visual compliance (OFAC) screening workflow
+-- approved_beneficiaries: whitelist of previously screened & approved payee names
+-- compliance_screenings: one screening record per F1 (err_projects row)
+
+CREATE TABLE IF NOT EXISTS approved_beneficiaries (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  normalized_key TEXT NOT NULL UNIQUE,
+  source TEXT NOT NULL DEFAULT 'import' CHECK (source IN ('import', 'screening_clearance')),
+  created_by UUID REFERENCES users(id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS compliance_screenings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL UNIQUE REFERENCES err_projects(id) ON DELETE CASCADE,
+  names JSONB NOT NULL DEFAULT '[]',
+  status TEXT NOT NULL DEFAULT 'pending_screening'
+    CHECK (status IN ('pending_screening', 'cleared', 'flagged', 'auto_approved')),
+  flag_note TEXT,
+  screened_by UUID REFERENCES users(id),
+  screened_at TIMESTAMPTZ,
+  finance_review_status TEXT
+    CHECK (finance_review_status IN ('pending', 'approved', 'rejected')),
+  finance_review_note TEXT,
+  finance_reviewed_by UUID REFERENCES users(id),
+  finance_reviewed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_compliance_screenings_status ON compliance_screenings(status);
+CREATE INDEX IF NOT EXISTS idx_compliance_screenings_project ON compliance_screenings(project_id);
+
+ALTER TABLE approved_beneficiaries ENABLE ROW LEVEL SECURITY;
+ALTER TABLE compliance_screenings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Authenticated can select" ON approved_beneficiaries
+  FOR SELECT TO authenticated USING (true);
+CREATE POLICY "Authenticated can insert" ON approved_beneficiaries
+  FOR INSERT TO authenticated WITH CHECK (true);
+CREATE POLICY "Authenticated can update" ON approved_beneficiaries
+  FOR UPDATE TO authenticated USING (true) WITH CHECK (true);
+CREATE POLICY "Authenticated can delete" ON approved_beneficiaries
+  FOR DELETE TO authenticated USING (true);
+
+CREATE POLICY "Authenticated can select" ON compliance_screenings
+  FOR SELECT TO authenticated USING (true);
+CREATE POLICY "Authenticated can insert" ON compliance_screenings
+  FOR INSERT TO authenticated WITH CHECK (true);
+CREATE POLICY "Authenticated can update" ON compliance_screenings
+  FOR UPDATE TO authenticated USING (true) WITH CHECK (true);
+CREATE POLICY "Authenticated can delete" ON compliance_screenings
+  FOR DELETE TO authenticated USING (true);

--- a/src/app/api/compliance/[id]/decision/route.ts
+++ b/src/app/api/compliance/[id]/decision/route.ts
@@ -1,0 +1,121 @@
+import { NextResponse } from 'next/server'
+import { getSupabaseRouteClient } from '@/lib/supabaseRouteClient'
+import { requirePermission } from '@/lib/requirePermission'
+import { normalizedNameKey, type FlagType } from '@/lib/compliance'
+import { sendSanctionsMatchAlert } from '@/lib/complianceAlerts'
+
+const VALID_FLAG_TYPES: FlagType[] = ['missing_id', 'sanctions_match']
+
+// POST /api/compliance/[id]/decision - Record a screening decision (clear or flag).
+// Flag requires flag_type: missing_id | sanctions_match
+export async function POST(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const perm = await requirePermission('compliance_screen')
+    if (perm instanceof NextResponse) return perm
+
+    const supabase = getSupabaseRouteClient()
+    const { action, note, flag_type } = await request.json()
+
+    if (action !== 'clear' && action !== 'flag') {
+      return NextResponse.json({ error: "action must be 'clear' or 'flag'" }, { status: 400 })
+    }
+
+    if (action === 'flag') {
+      if (!flag_type || !VALID_FLAG_TYPES.includes(flag_type)) {
+        return NextResponse.json(
+          { error: "flag_type is required: 'missing_id' or 'sanctions_match'" },
+          { status: 400 }
+        )
+      }
+      if (!note || !String(note).trim()) {
+        return NextResponse.json({ error: 'A note is required when flagging' }, { status: 400 })
+      }
+    }
+
+    const { data: screening, error: fetchError } = await supabase
+      .from('compliance_screenings')
+      .select(`
+        id, names, status, project_id,
+        err_projects ( err_id )
+      `)
+      .eq('id', params.id)
+      .single()
+    if (fetchError || !screening) {
+      return NextResponse.json({ error: 'Screening not found' }, { status: 404 })
+    }
+
+    const update: Record<string, unknown> = {
+      status: action === 'clear' ? 'cleared' : 'flagged',
+      flag_note: action === 'flag' ? String(note).trim() : null,
+      flag_type: action === 'flag' ? flag_type : null,
+      screened_by: perm.user.id,
+      screened_at: new Date().toISOString(),
+      finance_review_status: action === 'flag' ? 'pending' : null,
+      finance_review_note: null,
+      finance_reviewed_by: null,
+      finance_reviewed_at: null,
+      alerted_at: null
+    }
+
+    const { error: updateError } = await supabase
+      .from('compliance_screenings')
+      .update(update)
+      .eq('id', params.id)
+    if (updateError) throw updateError
+
+    // Whitelist cleared names for future auto-approval
+    if (action === 'clear') {
+      const names: string[] = Array.isArray(screening.names) ? screening.names : []
+      const rows = names
+        .map(name => ({ name, normalized_key: normalizedNameKey(name) }))
+        .filter(r => r.normalized_key.length > 0)
+        .map(r => ({
+          ...r,
+          source: 'screening_clearance',
+          created_by: perm.user.id
+        }))
+      if (rows.length > 0) {
+        const { error: whitelistError } = await supabase
+          .from('approved_beneficiaries')
+          .upsert(rows, { onConflict: 'normalized_key', ignoreDuplicates: true })
+        if (whitelistError) {
+          console.error('Error whitelisting cleared names:', whitelistError)
+        }
+      }
+    }
+
+    let alertDetail: string | undefined
+    if (action === 'flag' && flag_type === 'sanctions_match') {
+      const project = screening.err_projects as
+        | { err_id?: string | null }
+        | { err_id?: string | null }[]
+        | null
+      const errId = Array.isArray(project) ? project[0]?.err_id : project?.err_id
+      const alert = await sendSanctionsMatchAlert({
+        errId: errId || null,
+        projectId: screening.project_id,
+        names: Array.isArray(screening.names) ? screening.names : [],
+        note: String(note).trim(),
+        screeningId: screening.id
+      })
+      alertDetail = alert.detail
+      await supabase
+        .from('compliance_screenings')
+        .update({ alerted_at: new Date().toISOString() })
+        .eq('id', params.id)
+    }
+
+    return NextResponse.json({
+      success: true,
+      status: update.status,
+      flag_type: update.flag_type,
+      alert: alertDetail
+    })
+  } catch (error) {
+    console.error('Error recording screening decision:', error)
+    return NextResponse.json({ error: 'Failed to record decision' }, { status: 500 })
+  }
+}

--- a/src/app/api/compliance/[id]/finance-review/route.ts
+++ b/src/app/api/compliance/[id]/finance-review/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse } from 'next/server'
+import { getSupabaseRouteClient } from '@/lib/supabaseRouteClient'
+import { requirePermission } from '@/lib/requirePermission'
+
+/**
+ * POST /api/compliance/[id]/finance-review
+ *
+ * Actions:
+ *  - dismiss  — Ahmed raised the flag erroneously; clear the flag and unblock
+ *  - approve  — only for missing_id after an ID has been uploaded (or legacy flags)
+ *  - reject   — legacy alias for dismiss
+ *
+ * For sanctions_match, finance cannot "approve" a payment — only dismiss if erroneous.
+ * For missing_id, use upload-id endpoint to attach the ID and resolve.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const perm = await requirePermission('compliance_finance_review')
+    if (perm instanceof NextResponse) return perm
+
+    const supabase = getSupabaseRouteClient()
+    const { action, note } = await request.json()
+
+    const normalized =
+      action === 'reject' || action === 'dismiss'
+        ? 'dismiss'
+        : action === 'approve'
+          ? 'approve'
+          : null
+
+    if (!normalized) {
+      return NextResponse.json(
+        { error: "action must be 'dismiss' (or 'reject') or 'approve'" },
+        { status: 400 }
+      )
+    }
+
+    const { data: screening, error: fetchError } = await supabase
+      .from('compliance_screenings')
+      .select('id, status, flag_type, finance_review_status, project_id')
+      .eq('id', params.id)
+      .single()
+    if (fetchError || !screening) {
+      return NextResponse.json({ error: 'Screening not found' }, { status: 404 })
+    }
+    if (screening.status !== 'flagged') {
+      return NextResponse.json(
+        { error: 'Only flagged screenings can be finance-reviewed' },
+        { status: 400 }
+      )
+    }
+
+    if (normalized === 'approve') {
+      if (screening.flag_type === 'sanctions_match') {
+        return NextResponse.json(
+          {
+            error:
+              'Sanctions-match flags cannot be approved for payment. Dismiss only if the flag was raised in error, otherwise the payment must remain stopped.'
+          },
+          { status: 400 }
+        )
+      }
+      if (screening.flag_type === 'missing_id') {
+        // ID must already be on the project (uploaded via upload-id)
+        const { data: project } = await supabase
+          .from('err_projects')
+          .select('identity_document_file_key')
+          .eq('id', screening.project_id)
+          .single()
+        if (!project?.identity_document_file_key) {
+          return NextResponse.json(
+            { error: 'Upload the missing ID document before approving this flag' },
+            { status: 400 }
+          )
+        }
+      }
+    }
+
+    if (normalized === 'dismiss') {
+      // Erroneous flag — return to pending so Ahmed can re-screen if needed,
+      // and unblock commit
+      const { error: updateError } = await supabase
+        .from('compliance_screenings')
+        .update({
+          status: 'pending_screening',
+          flag_type: null,
+          flag_note: null,
+          finance_review_status: 'rejected',
+          finance_review_note: note
+            ? `Flag dismissed as erroneous: ${note}`
+            : 'Flag dismissed as erroneous',
+          finance_reviewed_by: perm.user.id,
+          finance_reviewed_at: new Date().toISOString()
+        })
+        .eq('id', params.id)
+      if (updateError) throw updateError
+      return NextResponse.json({ success: true, action: 'dismissed' })
+    }
+
+    // approve (missing_id with ID already uploaded, or legacy)
+    const { error: updateError } = await supabase
+      .from('compliance_screenings')
+      .update({
+        finance_review_status: 'approved',
+        finance_review_note: note || null,
+        finance_reviewed_by: perm.user.id,
+        finance_reviewed_at: new Date().toISOString()
+      })
+      .eq('id', params.id)
+    if (updateError) throw updateError
+
+    return NextResponse.json({ success: true, action: 'approved' })
+  } catch (error) {
+    console.error('Error recording finance review:', error)
+    return NextResponse.json({ error: 'Failed to record finance review' }, { status: 500 })
+  }
+}

--- a/src/app/api/compliance/[id]/upload-id/route.ts
+++ b/src/app/api/compliance/[id]/upload-id/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server'
+import { getSupabaseRouteClient } from '@/lib/supabaseRouteClient'
+import { requirePermission } from '@/lib/requirePermission'
+
+/**
+ * POST /api/compliance/[id]/upload-id
+ * Finance uploads a missing ID document for a missing_id flag.
+ * Body: { file_key: string } — storage path already uploaded to the images bucket.
+ * Saves the key onto err_projects.identity_document_file_key and marks the flag approved.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const perm = await requirePermission('compliance_finance_review')
+    if (perm instanceof NextResponse) return perm
+
+    const supabase = getSupabaseRouteClient()
+    const { file_key, note } = await request.json()
+
+    if (!file_key || typeof file_key !== 'string') {
+      return NextResponse.json({ error: 'file_key is required' }, { status: 400 })
+    }
+
+    const { data: screening, error: fetchError } = await supabase
+      .from('compliance_screenings')
+      .select('id, status, flag_type, project_id')
+      .eq('id', params.id)
+      .single()
+    if (fetchError || !screening) {
+      return NextResponse.json({ error: 'Screening not found' }, { status: 404 })
+    }
+    if (screening.status !== 'flagged' || screening.flag_type !== 'missing_id') {
+      return NextResponse.json(
+        { error: 'ID upload is only allowed for flagged missing_id screenings' },
+        { status: 400 }
+      )
+    }
+
+    const { error: projectError } = await supabase
+      .from('err_projects')
+      .update({ identity_document_file_key: file_key })
+      .eq('id', screening.project_id)
+    if (projectError) throw projectError
+
+    const { error: screeningError } = await supabase
+      .from('compliance_screenings')
+      .update({
+        finance_review_status: 'approved',
+        finance_review_note: note || 'Identity document uploaded',
+        finance_reviewed_by: perm.user.id,
+        finance_reviewed_at: new Date().toISOString()
+      })
+      .eq('id', params.id)
+    if (screeningError) throw screeningError
+
+    return NextResponse.json({
+      success: true,
+      identity_document_file_key: file_key
+    })
+  } catch (error) {
+    console.error('Error uploading identity document:', error)
+    return NextResponse.json({ error: 'Failed to save identity document' }, { status: 500 })
+  }
+}

--- a/src/app/api/compliance/ensure/route.ts
+++ b/src/app/api/compliance/ensure/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server'
+import { getSupabaseRouteClient } from '@/lib/supabaseRouteClient'
+import { ensureScreeningsForProjects } from '@/lib/compliance'
+
+// POST /api/compliance/ensure - Create compliance screenings for specific projects
+// Called after client-side F1 inserts so new F1s land in the screening queue immediately.
+export async function POST(request: Request) {
+  try {
+    const supabase = getSupabaseRouteClient()
+    const {
+      data: { session },
+      error: sessionError
+    } = await supabase.auth.getSession()
+    if (sessionError || !session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { project_ids } = await request.json()
+    if (!project_ids || !Array.isArray(project_ids) || project_ids.length === 0) {
+      return NextResponse.json({ error: 'project_ids array is required' }, { status: 400 })
+    }
+
+    const { data: projects, error } = await supabase
+      .from('err_projects')
+      .select('id, banking_details')
+      .in('id', project_ids)
+    if (error) throw error
+
+    const result = await ensureScreeningsForProjects(supabase, projects || [])
+    return NextResponse.json({ success: true, created: result.created })
+  } catch (error) {
+    console.error('Error ensuring compliance screenings:', error)
+    return NextResponse.json({ error: 'Failed to ensure screenings' }, { status: 500 })
+  }
+}

--- a/src/app/api/compliance/queue/route.ts
+++ b/src/app/api/compliance/queue/route.ts
@@ -1,0 +1,145 @@
+import { NextResponse } from 'next/server'
+import { getSupabaseRouteClient } from '@/lib/supabaseRouteClient'
+import { requirePermission } from '@/lib/requirePermission'
+import { sweepUnscreenedProjects } from '@/lib/compliance'
+
+// GET /api/compliance/queue - List compliance screenings joined with F1 details.
+// Runs an idempotent sweep first so F1s created outside portal API routes
+// (ERR App submissions, legacy inserts) and pre-existing F1s are backfilled.
+// Query params:
+//   status: filter by screening status (pending_screening | cleared | flagged | auto_approved)
+//   count_only: '1' to return only the pending count (for the sidebar badge)
+export async function GET(request: Request) {
+  try {
+    const perm = await requirePermission('compliance_view_page')
+    if (perm instanceof NextResponse) return perm
+
+    const supabase = getSupabaseRouteClient()
+    const { searchParams } = new URL(request.url)
+    const status = searchParams.get('status')
+    const countOnly = searchParams.get('count_only') === '1'
+
+    if (countOnly) {
+      // Lightweight path for the sidebar badge: no sweep, just the count
+      const { count, error } = await supabase
+        .from('compliance_screenings')
+        .select('id', { count: 'exact', head: true })
+        .eq('status', 'pending_screening')
+      if (error) throw error
+      return NextResponse.json({ pending_count: count || 0 })
+    }
+
+    try {
+      await sweepUnscreenedProjects(supabase)
+    } catch (sweepError) {
+      // Sweep failure shouldn't block viewing the existing queue
+      console.error('Compliance sweep error:', sweepError)
+    }
+
+    let query = supabase
+      .from('compliance_screenings')
+      .select(`
+        id,
+        project_id,
+        names,
+        status,
+        flag_type,
+        flag_note,
+        alerted_at,
+        screened_at,
+        finance_review_status,
+        finance_review_note,
+        finance_reviewed_at,
+        created_at,
+        err_projects (
+          id,
+          err_id,
+          date,
+          state,
+          locality,
+          status,
+          funding_status,
+          banking_details,
+          intended_beneficiaries,
+          project_objectives,
+          expenses,
+          temp_file_key,
+          identity_document_file_key,
+          emergency_rooms (err_code, name_ar, name)
+        )
+      `)
+      .order('created_at', { ascending: false })
+
+    if (status) {
+      query = query.eq('status', status)
+    }
+
+    const { data, error } = await query
+    if (error) throw error
+
+    type RoomJoin = { err_code?: string | null; name_ar?: string | null; name?: string | null }
+    type ProjectJoin = {
+      id?: string
+      err_id?: string | null
+      date?: string | null
+      state?: string | null
+      locality?: string | null
+      status?: string | null
+      funding_status?: string | null
+      banking_details?: string | null
+      intended_beneficiaries?: string | null
+      project_objectives?: string | null
+      expenses?: unknown
+      temp_file_key?: string | null
+      identity_document_file_key?: string | null
+      emergency_rooms?: RoomJoin | RoomJoin[] | null
+    }
+
+    const formatted = (data || []).map((row) => {
+      const rawProject = row.err_projects as unknown
+      const p: ProjectJoin = (Array.isArray(rawProject) ? rawProject[0] : rawProject) || {}
+      const rawRoom = p.emergency_rooms as unknown
+      const room: RoomJoin = (Array.isArray(rawRoom) ? rawRoom[0] : rawRoom) || {}
+      let expenses: Array<{ activity: string; total_cost: number }> = []
+      try {
+        expenses = typeof p.expenses === 'string'
+          ? JSON.parse(p.expenses)
+          : (p.expenses as Array<{ activity: string; total_cost: number }>) || []
+      } catch {
+        expenses = []
+      }
+      return {
+        id: row.id,
+        project_id: row.project_id,
+        names: row.names || [],
+        status: row.status,
+        flag_type: row.flag_type || null,
+        flag_note: row.flag_note,
+        alerted_at: row.alerted_at || null,
+        screened_at: row.screened_at,
+        finance_review_status: row.finance_review_status,
+        finance_review_note: row.finance_review_note,
+        finance_reviewed_at: row.finance_reviewed_at,
+        created_at: row.created_at,
+        err_id: p.err_id || null,
+        err_name: room.name_ar || room.name || null,
+        date: p.date || null,
+        state: p.state || null,
+        locality: p.locality || null,
+        project_status: p.status || null,
+        funding_status: p.funding_status || null,
+        banking_details: p.banking_details || null,
+        intended_beneficiaries: p.intended_beneficiaries || null,
+        project_objectives: p.project_objectives || null,
+        total_amount: expenses.reduce((sum, e) => sum + (e.total_cost || 0), 0),
+        temp_file_key: p.temp_file_key || null,
+        identity_document_file_key: p.identity_document_file_key || null
+      }
+    })
+
+    return NextResponse.json(formatted)
+  } catch (error) {
+    console.error('Error fetching compliance queue:', error)
+    return NextResponse.json({ error: 'Failed to fetch compliance queue' }, { status: 500 })
+  }
+}

--- a/src/app/api/f1/workplan/route.ts
+++ b/src/app/api/f1/workplan/route.ts
@@ -3,6 +3,7 @@ import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 import { normalizeF1DateForDb } from '@/lib/f1WorkplanNormalize'
 import { f1WorkplanCreateSchema } from '@/lib/f1WorkplanSchema'
+import { ensureScreeningsForProjects } from '@/lib/compliance'
 
 function emptyToNull<T extends string | null | undefined> (v: T): string | null {
   if (v === undefined || v === null) return null
@@ -113,6 +114,18 @@ export async function POST (request: Request) {
       const status =
         insertError.code === '23503' || insertError.code === '23514' ? 400 : 500
       return NextResponse.json({ error: msg }, { status })
+    }
+
+    // Queue the new F1 for visual compliance screening (non-fatal on failure;
+    // the compliance queue sweep will pick it up later if this errors)
+    if (inserted?.id) {
+      try {
+        await ensureScreeningsForProjects(supabase, [
+          { id: inserted.id, banking_details: row.banking_details }
+        ])
+      } catch (screeningError) {
+        console.error('f1/workplan compliance screening:', screeningError)
+      }
     }
 
     return NextResponse.json({ success: true, id: inserted?.id })

--- a/src/app/api/f2/uncommitted/commit/route.ts
+++ b/src/app/api/f2/uncommitted/commit/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getSupabaseRouteClient } from '@/lib/supabaseRouteClient'
 import { requirePermission } from '@/lib/requirePermission'
+import { getComplianceBlockedProjectIds } from '@/lib/compliance'
 
 // POST /api/f2/uncommitted/commit - Commit selected F1s (set funding_status to committed and status to approved)
 export async function POST(request: Request) {
@@ -13,6 +14,20 @@ export async function POST(request: Request) {
 
     if (!f1_ids || !Array.isArray(f1_ids) || f1_ids.length === 0) {
       return NextResponse.json({ error: 'F1 IDs array is required' }, { status: 400 })
+    }
+
+    // Compliance gate: F1s flagged by screening cannot be committed
+    // until the finance team approves them
+    const blocked = await getComplianceBlockedProjectIds(supabase, f1_ids)
+    if (blocked.length > 0) {
+      return NextResponse.json(
+        {
+          error: 'Some F1s are flagged by compliance screening and pending finance review. They cannot be committed.',
+          code: 'COMPLIANCE_BLOCKED',
+          blocked_ids: blocked
+        },
+        { status: 400 }
+      )
     }
 
     const { error } = await supabase

--- a/src/app/api/f2/uncommitted/route.ts
+++ b/src/app/api/f2/uncommitted/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { getSupabaseRouteClient } from '@/lib/supabaseRouteClient'
 import { getUserStateAccess } from '@/lib/userStateAccess'
 import { requirePermission } from '@/lib/requirePermission'
+import { getComplianceBlockedProjectIds } from '@/lib/compliance'
 
 // GET /api/f2/uncommitted - Get all uncommitted F1s (optional: state, month_year_from, month_year_to as YYYY-MM)
 export async function GET(request: Request) {
@@ -70,6 +71,39 @@ export async function GET(request: Request) {
 
     if (error) throw error
 
+    // Attach compliance screening status so the UI can badge/block flagged F1s
+    const complianceByProject = new Map<
+      string,
+      { status: string; finance_review_status: string | null; flag_type: string | null }
+    >()
+    const projectIds = (data || []).map((f1) => f1.id as string)
+    for (let i = 0; i < projectIds.length; i += 200) {
+      const chunk = projectIds.slice(i, i + 200)
+      const { data: screenings, error: screeningsError } = await supabase
+        .from('compliance_screenings')
+        .select('project_id, status, finance_review_status, flag_type')
+        .in('project_id', chunk)
+      if (screeningsError) {
+        console.error('Error fetching compliance screenings:', screeningsError)
+        break
+      }
+      for (const s of screenings || []) {
+        complianceByProject.set(s.project_id, {
+          status: s.status,
+          finance_review_status: s.finance_review_status,
+          flag_type: s.flag_type || null
+        })
+      }
+    }
+
+    const isBlocked = (c: { status: string; finance_review_status: string | null; flag_type: string | null } | undefined) => {
+      if (!c || c.status !== 'flagged') return false
+      if (c.finance_review_status === 'rejected') return false
+      if (c.flag_type === 'sanctions_match') return true
+      if (c.flag_type === 'missing_id') return c.finance_review_status !== 'approved'
+      return c.finance_review_status !== 'approved'
+    }
+
     const formattedF1s = (data || []).map((f1: any) => ({
       id: f1.id,
       err_id: f1.err_id,
@@ -89,7 +123,10 @@ export async function GET(request: Request) {
       approval_file_key: f1.approval_file_key || null,
       temp_file_key: f1.temp_file_key || null,
       grant_id: f1.grant_id || null,
-      grant_segment: f1.grant_segment || null
+      grant_segment: f1.grant_segment || null,
+      compliance_status: complianceByProject.get(f1.id)?.status || null,
+      compliance_flag_type: complianceByProject.get(f1.id)?.flag_type || null,
+      compliance_blocked: isBlocked(complianceByProject.get(f1.id))
     }))
 
     return NextResponse.json(formattedF1s)
@@ -158,6 +195,19 @@ export async function POST(request: Request) {
     
     if (!f1_ids || !Array.isArray(f1_ids) || f1_ids.length === 0) {
       return NextResponse.json({ error: 'F1 IDs array is required' }, { status: 400 })
+    }
+
+    // Compliance gate: flagged F1s need finance approval before commit
+    const blocked = await getComplianceBlockedProjectIds(supabase, f1_ids)
+    if (blocked.length > 0) {
+      return NextResponse.json(
+        {
+          error: 'Some F1s are flagged by compliance screening and pending finance review. They cannot be committed.',
+          code: 'COMPLIANCE_BLOCKED',
+          blocked_ids: blocked
+        },
+        { status: 400 }
+      )
     }
 
     const { error } = await supabase

--- a/src/app/err-portal/compliance/page.tsx
+++ b/src/app/err-portal/compliance/page.tsx
@@ -1,0 +1,676 @@
+'use client'
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { Badge } from '@/components/ui/badge'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Textarea } from '@/components/ui/textarea'
+import { FileText, Eye, ShieldCheck, ShieldAlert, IdCard, Siren, Upload } from 'lucide-react'
+import { useAllowedFunctions } from '@/hooks/useAllowedFunctions'
+import { supabase } from '@/lib/supabaseClient'
+
+type FlagType = 'missing_id' | 'sanctions_match'
+
+interface Screening {
+  id: string
+  project_id: string
+  names: string[]
+  status: 'pending_screening' | 'cleared' | 'flagged' | 'auto_approved'
+  flag_type: FlagType | null
+  flag_note: string | null
+  alerted_at: string | null
+  screened_at: string | null
+  finance_review_status: 'pending' | 'approved' | 'rejected' | null
+  finance_review_note: string | null
+  finance_reviewed_at: string | null
+  created_at: string
+  err_id: string | null
+  err_name: string | null
+  date: string | null
+  state: string | null
+  locality: string | null
+  project_status: string | null
+  funding_status: string | null
+  banking_details: string | null
+  intended_beneficiaries: string | null
+  project_objectives: string | null
+  total_amount: number
+  temp_file_key: string | null
+  identity_document_file_key: string | null
+}
+
+function StatusBadge({ s }: { s: Screening }) {
+  if (s.status === 'pending_screening') {
+    return <Badge variant="secondary" className="text-[10px] px-1.5 py-0">Pending screening</Badge>
+  }
+  if (s.status === 'auto_approved') {
+    return <Badge variant="default" className="text-[10px] px-1.5 py-0 bg-green-600">Auto-approved</Badge>
+  }
+  if (s.status === 'cleared') {
+    return <Badge variant="default" className="text-[10px] px-1.5 py-0 bg-green-600">Cleared</Badge>
+  }
+  if (s.flag_type === 'sanctions_match') {
+    if (s.finance_review_status === 'rejected') {
+      return <Badge variant="secondary" className="text-[10px] px-1.5 py-0">Sanctions flag dismissed</Badge>
+    }
+    return (
+      <Badge variant="destructive" className="text-[10px] px-1.5 py-0 font-semibold">
+        PAYMENT STOPPED — sanctions match
+      </Badge>
+    )
+  }
+  if (s.flag_type === 'missing_id') {
+    if (s.finance_review_status === 'approved') {
+      return <Badge variant="default" className="text-[10px] px-1.5 py-0 bg-green-600">Missing ID — document uploaded</Badge>
+    }
+    if (s.finance_review_status === 'rejected') {
+      return <Badge variant="secondary" className="text-[10px] px-1.5 py-0">Missing ID flag dismissed</Badge>
+    }
+    return <Badge variant="destructive" className="text-[10px] px-1.5 py-0">Missing ID — awaiting upload</Badge>
+  }
+  if (s.finance_review_status === 'approved') {
+    return <Badge variant="default" className="text-[10px] px-1.5 py-0 bg-amber-500">Flagged — finance approved</Badge>
+  }
+  if (s.finance_review_status === 'rejected') {
+    return <Badge variant="secondary" className="text-[10px] px-1.5 py-0">Flag dismissed</Badge>
+  }
+  return <Badge variant="destructive" className="text-[10px] px-1.5 py-0">Flagged — pending finance review</Badge>
+}
+
+export default function CompliancePage() {
+  const router = useRouter()
+  const { can, isLoading: permissionsLoading } = useAllowedFunctions()
+  const canViewPage = can('compliance_view_page')
+  const canScreen = can('compliance_screen')
+  const canFinanceReview = can('compliance_finance_review')
+
+  const [screenings, setScreenings] = useState<Screening[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [selected, setSelected] = useState<Screening | null>(null)
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [note, setNote] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [actionInfo, setActionInfo] = useState<string | null>(null)
+  const idFileInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (!permissionsLoading && !canViewPage) {
+      router.replace('/err-portal')
+    }
+  }, [permissionsLoading, canViewPage, router])
+
+  const fetchQueue = useCallback(async () => {
+    try {
+      const res = await fetch('/api/compliance/queue')
+      if (!res.ok) throw new Error('Failed to fetch compliance queue')
+      const data = await res.json()
+      setScreenings(data)
+    } catch (e) {
+      console.error('Error fetching compliance queue:', e)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchQueue()
+  }, [fetchQueue])
+
+  const openDetail = (s: Screening) => {
+    setSelected(s)
+    setNote('')
+    setActionError(null)
+    setActionInfo(null)
+    setDialogOpen(true)
+  }
+
+  const submitDecision = async (action: 'clear' | 'flag', flagType?: FlagType) => {
+    if (!selected) return
+    if (action === 'flag') {
+      if (!flagType) {
+        setActionError('Choose a flag type: Missing ID or Sanctions match.')
+        return
+      }
+      if (!note.trim()) {
+        setActionError('Please add a note explaining the flag.')
+        return
+      }
+    }
+    setActionError(null)
+    setActionInfo(null)
+    setIsSubmitting(true)
+    try {
+      const res = await fetch(`/api/compliance/${selected.id}/decision`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action,
+          note: note.trim() || undefined,
+          flag_type: action === 'flag' ? flagType : undefined
+        })
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({} as { error?: string }))
+        setActionError(err.error || `Failed to ${action} (HTTP ${res.status})`)
+        return
+      }
+      const result = await res.json()
+      if (result.alert) setActionInfo(result.alert)
+      setDialogOpen(false)
+      setSelected(null)
+      setNote('')
+      await fetchQueue()
+    } catch (e) {
+      console.error('Error recording decision:', e)
+      setActionError('Failed to record decision — check your connection and try again.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const submitFinanceReview = async (action: 'dismiss' | 'approve') => {
+    if (!selected) return
+    setActionError(null)
+    setIsSubmitting(true)
+    try {
+      const res = await fetch(`/api/compliance/${selected.id}/finance-review`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action, note: note.trim() || undefined })
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({} as { error?: string }))
+        setActionError(err.error || 'Failed to record finance review')
+        return
+      }
+      setDialogOpen(false)
+      await fetchQueue()
+    } catch (e) {
+      console.error('Error recording finance review:', e)
+      setActionError('Failed to record finance review')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const uploadIdentityDocument = async (file: File) => {
+    if (!selected) return
+    setActionError(null)
+    setIsSubmitting(true)
+    try {
+      const ext = file.name.split('.').pop() || 'pdf'
+      const key = `compliance-ids/${selected.project_id}/${Date.now()}-${file.name.replace(/\s+/g, '_') || `id.${ext}`}`
+      const { error: upErr } = await supabase.storage.from('images').upload(key, file, { upsert: true })
+      if (upErr) {
+        setActionError(`Upload failed: ${upErr.message}`)
+        return
+      }
+      const res = await fetch(`/api/compliance/${selected.id}/upload-id`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ file_key: key, note: note.trim() || undefined })
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({} as { error?: string }))
+        setActionError(err.error || 'Failed to attach ID to F1')
+        return
+      }
+      setDialogOpen(false)
+      await fetchQueue()
+    } catch (e) {
+      console.error('Error uploading ID:', e)
+      setActionError('Failed to upload identity document')
+    } finally {
+      setIsSubmitting(false)
+      if (idFileInputRef.current) idFileInputRef.current.value = ''
+    }
+  }
+
+  const openFile = async (fileKey: string) => {
+    try {
+      const res = await fetch(`/api/storage/signed-url?path=${encodeURIComponent(fileKey)}`)
+      if (!res.ok) throw new Error('Failed to get file URL')
+      const { url } = await res.json()
+      if (url) window.open(url, '_blank')
+      else alert('File not available')
+    } catch (e) {
+      console.error('Error opening file:', e)
+      alert('Failed to open file')
+    }
+  }
+
+  if (!canViewPage) return null
+  if (isLoading) return <div className="text-center py-8">Loading...</div>
+
+  const pending = screenings.filter(s => s.status === 'pending_screening')
+  const financeQueue = screenings.filter(
+    s => s.status === 'flagged' && s.finance_review_status === 'pending'
+  )
+  const sanctionsAlerts = screenings.filter(
+    s =>
+      s.status === 'flagged' &&
+      s.flag_type === 'sanctions_match' &&
+      s.finance_review_status === 'pending'
+  )
+  const history = screenings.filter(
+    s =>
+      s.status !== 'pending_screening' &&
+      !(s.status === 'flagged' && s.finance_review_status === 'pending')
+  )
+
+  const renderTable = (rows: Screening[], emptyText: string) => (
+    <Card>
+      <CardContent className="p-0 overflow-x-auto">
+        <Table className="text-xs min-w-[700px]">
+          <TableHeader>
+            <TableRow className="[&>th]:py-2 [&>th]:px-2 [&>th]:text-xs">
+              <TableHead className="px-2">ERR ID</TableHead>
+              <TableHead className="px-2">Date</TableHead>
+              <TableHead className="px-2">State</TableHead>
+              <TableHead className="px-2">Locality</TableHead>
+              <TableHead className="px-2">Payee names</TableHead>
+              <TableHead className="text-right px-2">Amount</TableHead>
+              <TableHead className="px-2">Status</TableHead>
+              <TableHead className="px-2">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={8} className="text-center py-6 text-muted-foreground">
+                  {emptyText}
+                </TableCell>
+              </TableRow>
+            )}
+            {rows.map(s => (
+              <TableRow
+                key={s.id}
+                className={`[&>td]:py-1.5 [&>td]:px-2 [&>td]:text-xs ${
+                  s.flag_type === 'sanctions_match' && s.finance_review_status === 'pending'
+                    ? 'bg-red-50'
+                    : ''
+                }`}
+              >
+                <TableCell className="whitespace-nowrap">{s.err_id || '—'}</TableCell>
+                <TableCell className="whitespace-nowrap">
+                  {s.date ? new Date(s.date).toLocaleDateString() : '—'}
+                </TableCell>
+                <TableCell className="whitespace-nowrap">{s.state || '—'}</TableCell>
+                <TableCell className="whitespace-nowrap max-w-[100px] truncate" title={s.locality || ''}>
+                  {s.locality || '—'}
+                </TableCell>
+                <TableCell className="max-w-[220px]">
+                  {s.names.length > 0 ? (
+                    <span className="truncate block" title={s.names.join(', ')}>
+                      {s.names.join(', ')}
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground italic">No names extracted</span>
+                  )}
+                </TableCell>
+                <TableCell className="text-right whitespace-nowrap">
+                  {s.total_amount ? s.total_amount.toLocaleString() : '—'}
+                </TableCell>
+                <TableCell className="whitespace-nowrap">
+                  <StatusBadge s={s} />
+                </TableCell>
+                <TableCell className="whitespace-nowrap">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 text-xs px-2"
+                    onClick={() => openDetail(s)}
+                  >
+                    <Eye className="w-3.5 h-3.5 mr-1" />
+                    View F1
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  )
+
+  const showScreeningActions =
+    canScreen && selected?.status === 'pending_screening'
+  const showMissingIdFinance =
+    canFinanceReview &&
+    selected?.status === 'flagged' &&
+    selected?.flag_type === 'missing_id' &&
+    selected?.finance_review_status === 'pending'
+  const showSanctionsFinance =
+    canFinanceReview &&
+    selected?.status === 'flagged' &&
+    selected?.flag_type === 'sanctions_match' &&
+    selected?.finance_review_status === 'pending'
+  const showLegacyFinance =
+    canFinanceReview &&
+    selected?.status === 'flagged' &&
+    !selected?.flag_type &&
+    selected?.finance_review_status === 'pending'
+
+  return (
+    <div className="max-w-7xl mx-auto p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-semibold">Visual Compliance</h2>
+        <Button variant="outline" onClick={() => router.push('/err-portal')}>
+          Back
+        </Button>
+      </div>
+
+      {sanctionsAlerts.length > 0 && (
+        <div className="rounded-md border-2 border-red-600 bg-red-50 px-4 py-3 text-red-950">
+          <div className="flex items-start gap-2">
+            <Siren className="h-5 w-5 mt-0.5 shrink-0 text-red-600" />
+            <div>
+              <div className="font-semibold text-sm">
+                RED ALERT — {sanctionsAlerts.length} payment{sanctionsAlerts.length === 1 ? '' : 's'} must be stopped
+              </div>
+              <p className="text-sm mt-1">
+                Potential Descartes / sanctions list match flagged. Notify Finance, Ahmed, Yara, Josh, Nihal, and Santiago.
+                {' '}
+                {sanctionsAlerts.map(s => s.err_id || s.project_id).join(', ')}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>OFAC / Descartes Screening</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Ahmed screens payee names. Flag as <strong>Missing ID</strong> (finance uploads the document)
+            or <strong>Sanctions match</strong> (payment stopped — red alert). Clear when the name is fine.
+          </p>
+        </CardHeader>
+        <CardContent>
+          <Tabs defaultValue="queue" className="w-full">
+            <TabsList className="grid w-full grid-cols-3">
+              <TabsTrigger value="queue">
+                Screening queue{pending.length > 0 ? ` (${pending.length})` : ''}
+              </TabsTrigger>
+              <TabsTrigger value="finance">
+                Finance review{financeQueue.length > 0 ? ` (${financeQueue.length})` : ''}
+              </TabsTrigger>
+              <TabsTrigger value="history">History</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="queue" className="mt-6">
+              {renderTable(pending, 'No F1s waiting for screening')}
+            </TabsContent>
+
+            <TabsContent value="finance" className="mt-6">
+              {renderTable(financeQueue, 'No flagged F1s waiting for finance review')}
+            </TabsContent>
+
+            <TabsContent value="history" className="mt-6">
+              {renderTable(history, 'No screened F1s yet')}
+            </TabsContent>
+          </Tabs>
+        </CardContent>
+      </Card>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="sm:max-w-2xl mx-4 max-h-[85vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>
+              F1 Compliance Review {selected?.err_id ? `— ${selected.err_id}` : ''}
+            </DialogTitle>
+          </DialogHeader>
+          {selected && (
+            <div className="space-y-4">
+              {selected.flag_type === 'sanctions_match' &&
+                selected.finance_review_status === 'pending' && (
+                <div className="rounded-md border-2 border-red-600 bg-red-50 px-3 py-2 text-sm text-red-950 font-medium">
+                  PAYMENT MUST BE STOPPED — potential Descartes / sanctions list match.
+                  Alert recipients: Finance, Ahmed, Yara, Josh, Nihal, Santiago.
+                </div>
+              )}
+
+              <div className="flex items-center gap-2 flex-wrap">
+                <StatusBadge s={selected} />
+                {selected.funding_status && (
+                  <Badge variant="outline" className="text-[10px] px-1.5 py-0">
+                    {selected.funding_status}
+                  </Badge>
+                )}
+              </div>
+
+              <div className="grid grid-cols-2 gap-3 text-sm">
+                <div>
+                  <div className="text-xs text-muted-foreground">ERR</div>
+                  <div>{selected.err_name || selected.err_id || '—'}</div>
+                </div>
+                <div>
+                  <div className="text-xs text-muted-foreground">Date</div>
+                  <div>{selected.date ? new Date(selected.date).toLocaleDateString() : '—'}</div>
+                </div>
+                <div>
+                  <div className="text-xs text-muted-foreground">State / Locality</div>
+                  <div>{[selected.state, selected.locality].filter(Boolean).join(' — ') || '—'}</div>
+                </div>
+                <div>
+                  <div className="text-xs text-muted-foreground">Requested amount</div>
+                  <div>{selected.total_amount ? selected.total_amount.toLocaleString() : '—'}</div>
+                </div>
+              </div>
+
+              <div>
+                <div className="text-xs text-muted-foreground mb-1">Payee names to screen</div>
+                {selected.names.length > 0 ? (
+                  <div className="flex flex-wrap gap-1.5">
+                    {selected.names.map(name => (
+                      <Badge key={name} variant="secondary" className="text-xs">
+                        {name}
+                      </Badge>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-sm text-muted-foreground italic">
+                    No names could be extracted automatically — screen banking details manually.
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <div className="text-xs text-muted-foreground mb-1">Banking details</div>
+                <pre className="text-sm whitespace-pre-wrap bg-muted rounded-md p-3 max-h-48 overflow-y-auto font-sans">
+                  {selected.banking_details || '—'}
+                </pre>
+              </div>
+
+              {selected.intended_beneficiaries && (
+                <div>
+                  <div className="text-xs text-muted-foreground mb-1">Intended beneficiaries</div>
+                  <pre className="text-sm whitespace-pre-wrap bg-muted rounded-md p-3 max-h-32 overflow-y-auto font-sans">
+                    {selected.intended_beneficiaries}
+                  </pre>
+                </div>
+              )}
+
+              <div className="flex flex-wrap gap-2">
+                {selected.temp_file_key && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => openFile(selected.temp_file_key as string)}
+                  >
+                    <FileText className="w-4 h-4 mr-1" />
+                    Open original F1 file
+                  </Button>
+                )}
+                {selected.identity_document_file_key && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => openFile(selected.identity_document_file_key as string)}
+                  >
+                    <IdCard className="w-4 h-4 mr-1" />
+                    Open uploaded ID
+                  </Button>
+                )}
+              </div>
+
+              {selected.flag_note && (
+                <div>
+                  <div className="text-xs text-muted-foreground mb-1">Screening flag note</div>
+                  <p className="text-sm bg-red-50 text-red-900 rounded-md p-3">{selected.flag_note}</p>
+                </div>
+              )}
+
+              {selected.finance_review_note && (
+                <div>
+                  <div className="text-xs text-muted-foreground mb-1">Finance review note</div>
+                  <p className="text-sm bg-muted rounded-md p-3">{selected.finance_review_note}</p>
+                </div>
+              )}
+
+              {(showScreeningActions ||
+                showMissingIdFinance ||
+                showSanctionsFinance ||
+                showLegacyFinance) && (
+                <div className="space-y-2 border-t pt-4 sticky bottom-0 bg-white dark:bg-slate-950 pb-1">
+                  <div className="text-xs text-muted-foreground">
+                    {showScreeningActions
+                      ? 'Note (required when flagging)'
+                      : 'Finance note (optional)'}
+                  </div>
+                  <Textarea
+                    value={note}
+                    onChange={e => {
+                      setNote(e.target.value)
+                      if (actionError) setActionError(null)
+                    }}
+                    placeholder={
+                      showScreeningActions
+                        ? 'e.g. No national ID attached / Possible Descartes list match for …'
+                        : 'e.g. ID verified and uploaded / Flag raised in error — wrong person'
+                    }
+                    rows={2}
+                  />
+                  {actionError && (
+                    <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-md px-3 py-2">
+                      {actionError}
+                    </p>
+                  )}
+                  {actionInfo && (
+                    <p className="text-sm text-amber-800 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
+                      {actionInfo}
+                    </p>
+                  )}
+
+                  {showScreeningActions && (
+                    <div className="flex flex-wrap justify-end gap-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        disabled={isSubmitting}
+                        onClick={() => submitDecision('flag', 'missing_id')}
+                      >
+                        <IdCard className="w-4 h-4 mr-1" />
+                        Flag: Missing ID
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="destructive"
+                        disabled={isSubmitting}
+                        onClick={() => submitDecision('flag', 'sanctions_match')}
+                      >
+                        <Siren className="w-4 h-4 mr-1" />
+                        Flag: Sanctions match
+                      </Button>
+                      <Button
+                        type="button"
+                        disabled={isSubmitting}
+                        onClick={() => submitDecision('clear')}
+                      >
+                        <ShieldCheck className="w-4 h-4 mr-1" />
+                        Clear
+                      </Button>
+                    </div>
+                  )}
+
+                  {showMissingIdFinance && (
+                    <div className="flex flex-wrap justify-end gap-2">
+                      <input
+                        ref={idFileInputRef}
+                        type="file"
+                        className="hidden"
+                        accept=".pdf,.jpg,.jpeg,.png,.doc,.docx,image/*,application/pdf"
+                        onChange={e => {
+                          const file = e.target.files?.[0]
+                          if (file) void uploadIdentityDocument(file)
+                        }}
+                      />
+                      <Button
+                        type="button"
+                        variant="outline"
+                        disabled={isSubmitting}
+                        onClick={() => submitFinanceReview('dismiss')}
+                      >
+                        Dismiss flag (raised in error)
+                      </Button>
+                      <Button
+                        type="button"
+                        disabled={isSubmitting}
+                        onClick={() => idFileInputRef.current?.click()}
+                      >
+                        <Upload className="w-4 h-4 mr-1" />
+                        {isSubmitting ? 'Uploading…' : 'Upload ID to F1'}
+                      </Button>
+                    </div>
+                  )}
+
+                  {showSanctionsFinance && (
+                    <div className="flex flex-wrap justify-end gap-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        disabled={isSubmitting}
+                        onClick={() => submitFinanceReview('dismiss')}
+                      >
+                        Dismiss flag (raised in error)
+                      </Button>
+                      <Button type="button" variant="destructive" disabled>
+                        <ShieldAlert className="w-4 h-4 mr-1" />
+                        Payment remains stopped
+                      </Button>
+                    </div>
+                  )}
+
+                  {showLegacyFinance && (
+                    <div className="flex flex-wrap justify-end gap-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        disabled={isSubmitting}
+                        onClick={() => submitFinanceReview('dismiss')}
+                      >
+                        Dismiss flag
+                      </Button>
+                      <Button
+                        type="button"
+                        disabled={isSubmitting}
+                        onClick={() => submitFinanceReview('approve')}
+                      >
+                        Approve — allow commit
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/src/app/err-portal/f2-approvals/components/UncommittedF1sTab.tsx
+++ b/src/app/err-portal/f2-approvals/components/UncommittedF1sTab.tsx
@@ -120,7 +120,8 @@ export default function UncommittedF1sTab() {
 
   const handleSelectAll = (checked: boolean) => {
     if (checked) {
-      setSelectedF1s(f1s.map(f1 => f1.id))
+      // Compliance-blocked F1s cannot be committed, so they are not selectable
+      setSelectedF1s(f1s.filter(f1 => !f1.compliance_blocked).map(f1 => f1.id))
     } else {
       setSelectedF1s([])
     }
@@ -207,7 +208,12 @@ export default function UncommittedF1sTab() {
       })
 
       if (!response.ok) {
-        alert('Failed to commit F1s')
+        const err: { error?: string; code?: string } = await response.json().catch(() => ({}))
+        if (err.code === 'COMPLIANCE_BLOCKED') {
+          alert('Cannot commit: one or more selected F1s are blocked by compliance (missing ID or sanctions match — payment stopped).')
+        } else {
+          alert(err.error || 'Failed to commit F1s')
+        }
         return
       }
 
@@ -370,6 +376,7 @@ export default function UncommittedF1sTab() {
                 <TableHead className="px-2">{t('f2:state')}</TableHead>
                 <TableHead className="px-2">{t('f2:locality')}</TableHead>
                 <TableHead className="text-right px-2">{t('f2:requested_amount')}</TableHead>
+                <TableHead className="px-2">Compliance</TableHead>
                 <TableHead className="px-2">{t('f2:community_approval')}</TableHead>
                 <TableHead className="px-2">{t('f2:actions') || 'Actions'}</TableHead>
                 {/* Status column removed visually */}
@@ -382,6 +389,8 @@ export default function UncommittedF1sTab() {
                     {canCommit && (
                       <Checkbox
                         checked={selectedF1s.includes(f1.id)}
+                        disabled={!!f1.compliance_blocked}
+                        title={f1.compliance_blocked ? 'Flagged by compliance screening — pending finance review' : undefined}
                         onCheckedChange={(checked) => handleSelectF1(f1.id, checked as boolean)}
                       />
                     )}
@@ -463,6 +472,32 @@ export default function UncommittedF1sTab() {
                           </Button>
                         )}
                       </div>
+                    )}
+                  </TableCell>
+                  {/* Compliance screening status */}
+                  <TableCell className="whitespace-nowrap">
+                    {f1.compliance_flag_type === 'sanctions_match' && f1.compliance_blocked ? (
+                      <Badge variant="destructive" className="text-[10px] px-1.5 py-0 font-semibold" title="Potential Descartes/sanctions match — payment must be stopped">
+                        PAYMENT STOPPED
+                      </Badge>
+                    ) : f1.compliance_blocked ? (
+                      <Badge variant="destructive" className="text-[10px] px-1.5 py-0" title="Missing ID — finance must upload the document or dismiss the flag">
+                        {f1.compliance_flag_type === 'missing_id' ? 'Missing ID' : 'Flagged — compliance'}
+                      </Badge>
+                    ) : f1.compliance_status === 'pending_screening' ? (
+                      <Badge variant="secondary" className="text-muted-foreground text-[10px] px-1.5 py-0">
+                        Screening pending
+                      </Badge>
+                    ) : f1.compliance_status === 'flagged' ? (
+                      <Badge variant="default" className="text-[10px] px-1.5 py-0 bg-amber-500">
+                        Finance resolved
+                      </Badge>
+                    ) : f1.compliance_status ? (
+                      <Badge variant="default" className="text-[10px] px-1.5 py-0 bg-green-600">
+                        Cleared
+                      </Badge>
+                    ) : (
+                      <span className="text-muted-foreground">—</span>
                     )}
                   </TableCell>
                   {/* Community Approval */}

--- a/src/app/err-portal/f2-approvals/types/index.ts
+++ b/src/app/err-portal/f2-approvals/types/index.ts
@@ -39,6 +39,9 @@ export interface UncommittedF1 {
   grant_id?: string | null
   grant_serial_id?: string | null
   workplan_number?: number | null
+  compliance_status?: 'pending_screening' | 'cleared' | 'flagged' | 'auto_approved' | null
+  compliance_flag_type?: 'missing_id' | 'sanctions_match' | null
+  compliance_blocked?: boolean
 }
 
 export interface CommittedF1 {

--- a/src/app/err-portal/fsystem-upload/components/F1Upload.tsx
+++ b/src/app/err-portal/fsystem-upload/components/F1Upload.tsx
@@ -369,7 +369,7 @@ export default function F1Upload() {
       }
 
       // Insert into Supabase with final grant ID and sectors
-      const { error: insertError } = await supabase
+      const { data: insertedProject, error: insertError } = await supabase
         .from('err_projects')
         .insert([{
           ...editedData,
@@ -386,9 +386,25 @@ export default function F1Upload() {
           "Sector (Secondary)": secondarySectorNames,
           project_name: projectName
         }])
+        .select('id')
+        .single()
 
       if (insertError) {
         throw insertError
+      }
+
+      // Queue the new F1 for visual compliance screening (non-fatal;
+      // the compliance queue sweep picks it up if this fails)
+      if (insertedProject?.id) {
+        try {
+          await fetch('/api/compliance/ensure', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ project_ids: [insertedProject.id] })
+          })
+        } catch (e) {
+          console.error('Failed to queue compliance screening:', e)
+        }
       }
 
       // Update Google Sheet with final grant ID and sectors

--- a/src/app/err-portal/layout.tsx
+++ b/src/app/err-portal/layout.tsx
@@ -7,7 +7,7 @@ import PageExplainerHeader from '@/components/layout/PageExplainerHeader'
 import { PageExplainerProvider } from '@/contexts/PageExplainerContext'
 import type { SidebarItem, SidebarLinkItem } from '@/components/layout/Sidebar'
 import { useRouter } from 'next/navigation'
-import { Users, ClipboardList, BarChart2, BarChart3, PieChart, UserCog, Home, CheckSquare, BookOpen, PenTool, Cog, FileText, BookMarked, Ticket } from 'lucide-react'
+import { Users, ClipboardList, BarChart2, BarChart3, PieChart, UserCog, Home, CheckSquare, BookOpen, PenTool, Cog, FileText, BookMarked, Ticket, ShieldCheck } from 'lucide-react'
 import { supabase } from '@/lib/supabaseClient'
 import { useAllowedFunctions } from '@/hooks/useAllowedFunctions'
 
@@ -28,6 +28,7 @@ export default function ErrPortalLayout({
   const { t } = useTranslation(['err'])
   const [user, setUser] = useState<User | null>(null)
   const [minimizedType, setMinimizedType] = useState<'f4'|'f5'|null>(null)
+  const [compliancePendingCount, setCompliancePendingCount] = useState<number>(0)
   const router = useRouter()
 
   useEffect(() => {
@@ -64,8 +65,21 @@ export default function ErrPortalLayout({
     return () => window.removeEventListener('storage', onStorage)
   }, [])
 
-  const { can } = useAllowedFunctions()
+  const { can, isLoading: permissionsLoading } = useAllowedFunctions()
   const canViewGrantManagement = can('grant_view')
+  const canViewCompliance = can('compliance_view_page')
+
+  useEffect(() => {
+    if (permissionsLoading || !canViewCompliance) return
+    let cancelled = false
+    fetch('/api/compliance/queue?count_only=1')
+      .then(r => (r.ok ? r.json() : { pending_count: 0 }))
+      .then(data => {
+        if (!cancelled) setCompliancePendingCount(data.pending_count ?? 0)
+      })
+      .catch(() => {})
+    return () => { cancelled = true }
+  }, [permissionsLoading, canViewCompliance])
   const canViewF1 = can('f1_view_page')
   const canViewF2 = can('f2_view_page')
   const canViewF3 = can('f3_view_page')
@@ -168,6 +182,11 @@ export default function ErrPortalLayout({
       href: '/err-portal/f4-f5-reporting',
       label: 'F4 & F5 Reporting',
       icon: <BookOpen className="h-5 w-5" />
+    }] : []),
+    ...(canViewCompliance ? [{
+      href: '/err-portal/compliance',
+      label: compliancePendingCount > 0 ? `Compliance (${compliancePendingCount})` : 'Compliance',
+      icon: <ShieldCheck className="h-5 w-5" />
     }] : []),
     ...(reportingGroupChildren.length > 0 ? [{
       type: 'group' as const,

--- a/src/data/functions.json
+++ b/src/data/functions.json
@@ -44,5 +44,8 @@
   { "code": "dashboard_view_page", "module": "dashboard", "label_ar": "عرض لوحة التحكم", "label_en": "View Dashboard page", "description_en": "View the ERR Portal Dashboard page." },
   { "code": "learnings_view_page", "module": "learnings", "label_ar": "عرض صفحة تعلم المساعدة المتبادلة", "label_en": "View Mutual Aid Learnings page", "description_en": "View the Mutual Aid Learnings (stories) page." },
   { "code": "surveys_view_page", "module": "surveys", "label_ar": "عرض صفحة الاستبيانات", "label_en": "View Surveys page", "description_en": "View the Surveys page for user feedback surveys." },
-  { "code": "raise_ticket_page", "module": "tickets", "label_ar": "فتح تذكرة (GitHub)", "label_en": "Raise a ticket", "description_en": "Use Raise a ticket to submit GitHub issues for the Mutual Aid Portal." }
+  { "code": "raise_ticket_page", "module": "tickets", "label_ar": "فتح تذكرة (GitHub)", "label_en": "Raise a ticket", "description_en": "Use Raise a ticket to submit GitHub issues for the Mutual Aid Portal." },
+  { "code": "compliance_view_page", "module": "compliance", "label_ar": "عرض صفحة الامتثال", "label_en": "View Compliance page", "description_en": "View the Visual Compliance (OFAC screening) page and queue." },
+  { "code": "compliance_screen", "module": "compliance", "label_ar": "فحص أسماء المستفيدين", "label_en": "Screen payee names", "description_en": "Clear or flag F1 payee names in the compliance screening queue (visual OFAC check)." },
+  { "code": "compliance_finance_review", "module": "compliance", "label_ar": "مراجعة مالية للمشاريع الموسومة", "label_en": "Finance review flagged F1s", "description_en": "Approve or reject flagged F1s so they can (or cannot) proceed to the committed stage." }
 ]

--- a/src/lib/compliance.ts
+++ b/src/lib/compliance.ts
@@ -36,6 +36,28 @@ export function normalizedNameKey(name: string): string {
     .join('|')
 }
 
+/**
+ * Combined EN+AR "alpha" key: the English key and the Arabic key joined into a
+ * single identity for one beneficiary (e.g. "ahmed:1|ali:1::احمد:1|علي:1").
+ *
+ * This is the most precise, discrepancy-proof match because it requires BOTH the
+ * English and Arabic name to line up — it also disambiguates Arabic names that
+ * share the same token multiset in a different order.
+ *
+ * NOTE: it is intentionally NOT yet used for live screening. Incoming F1 banking
+ * details currently carry only ONE language (~97% English), so a combined key
+ * cannot be built at screening time and would flag every payee for manual review.
+ * We keep it here, ready to switch on once the F1 intake captures a structured
+ * English AND Arabic beneficiary name (with a single-language fallback). Until
+ * then screening stays per-language (see ensureScreeningsForProjects).
+ */
+export function combinedNameKey(nameEn: string, nameAr: string): string | null {
+  const keyEn = normalizedNameKey(nameEn)
+  const keyAr = normalizedNameKey(nameAr)
+  if (!keyEn || !keyAr) return null
+  return `${keyEn}::${keyAr}`
+}
+
 /** Extract candidate payee names from a free-text banking details blob. */
 export function extractNamesFromBanking(text: string | null | undefined): string[] {
   if (!text) return []

--- a/src/lib/compliance.ts
+++ b/src/lib/compliance.ts
@@ -1,0 +1,221 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+// Visual compliance (OFAC) screening helpers.
+// Name extraction/normalization ported from scripts/screen-sanctions-strict.py
+// so portal-side matching stays consistent with the offline sanctions screen.
+
+const STOP_WORDS = new Set([
+  'bin', 'ibn', 'mr', 'mrs', 'dr', 'the', 'of', 'for',
+  'name', 'account', 'number', 'bank', 'signature'
+])
+
+export type ScreeningStatus = 'pending_screening' | 'cleared' | 'flagged' | 'auto_approved'
+export type FinanceReviewStatus = 'pending' | 'approved' | 'rejected'
+export type FlagType = 'missing_id' | 'sanctions_match'
+
+/** Tokenize a payee name: lowercase, keep latin + arabic letters, drop stopwords/digits. */
+export function nameTokens(name: string): string[] {
+  const cleaned = (name || '').toLowerCase().replace(/[^a-z\u0600-\u06ff\s]/g, ' ')
+  return cleaned
+    .split(/\s+/)
+    .filter(w => w.length > 1 && !STOP_WORDS.has(w) && !/^\d+$/.test(w))
+}
+
+/**
+ * Stable normalized key for a name (token multiset), e.g. "ali:2|mohammed:1".
+ * Used as the unique key in approved_beneficiaries.
+ */
+export function normalizedNameKey(name: string): string {
+  const counts = new Map<string, number>()
+  for (const tok of nameTokens(name)) {
+    counts.set(tok, (counts.get(tok) || 0) + 1)
+  }
+  return Array.from(counts.entries())
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([tok, n]) => `${tok}:${n}`)
+    .join('|')
+}
+
+/** Extract candidate payee names from a free-text banking details blob. */
+export function extractNamesFromBanking(text: string | null | undefined): string[] {
+  if (!text) return []
+  const names = new Set<string>()
+
+  // Explicit "Name: ..." lines (latin form; arabic bank text keeps the latin label in our data)
+  const nameLineRe = /(?:^|\n)\s*Name\s*:\s*([^\n]+)/gi
+  let m: RegExpExecArray | null
+  while ((m = nameLineRe.exec(text)) !== null) {
+    const candidate = m[1].trim()
+    if (candidate.length > 2) names.add(candidate)
+  }
+
+  // First few non-banking lines that look like a person's name
+  const bankKeywordRe = /bank|account|number|iban|signature|date\s*:|بنك/i
+  const lines = text.split('\n').map(l => l.trim()).filter(Boolean).slice(0, 4)
+  for (const line of lines) {
+    if (bankKeywordRe.test(line) || /^\d+$/.test(line.replace(/\s/g, ''))) continue
+    if (line.length >= 6 && line.length < 100 && line.split(/\s+/).length >= 2) {
+      names.add(line.replace(/^(the works of)\s+/i, ''))
+    }
+  }
+
+  // Keep names with at least two meaningful tokens; dedupe variants of the
+  // same name (e.g. "Name: X" vs "X"), preferring the one without a label
+  const byKey = new Map<string, string>()
+  for (const candidate of names) {
+    if (nameTokens(candidate).length < 2) continue
+    const key = normalizedNameKey(candidate)
+    const cleaned = candidate.replace(/^\s*Name\s*:\s*/i, '').trim()
+    const existing = byKey.get(key)
+    if (!existing || cleaned.length < existing.length) {
+      byKey.set(key, cleaned)
+    }
+  }
+  return Array.from(byKey.values())
+}
+
+/**
+ * Ensure a compliance screening row exists for each given project.
+ * Projects whose extracted names are all on the approved_beneficiaries
+ * whitelist are auto-approved; everything else lands in the pending queue.
+ *
+ * Idempotent: projects that already have a screening are skipped
+ * (compliance_screenings.project_id is unique).
+ */
+export async function ensureScreeningsForProjects(
+  supabase: SupabaseClient,
+  projects: Array<{ id: string; banking_details: string | null }>
+): Promise<{ created: number }> {
+  const candidates = projects.filter(p => (p.banking_details || '').trim().length > 0)
+  if (candidates.length === 0) return { created: 0 }
+
+  const ids = candidates.map(p => p.id)
+  const existing = new Set<string>()
+  for (let i = 0; i < ids.length; i += 200) {
+    const chunk = ids.slice(i, i + 200)
+    const { data, error } = await supabase
+      .from('compliance_screenings')
+      .select('project_id')
+      .in('project_id', chunk)
+    if (error) throw error
+    for (const row of data || []) existing.add(row.project_id)
+  }
+
+  const missing = candidates.filter(p => !existing.has(p.id))
+  if (missing.length === 0) return { created: 0 }
+
+  // Collect normalized keys across all missing projects for one whitelist lookup
+  const extracted = missing.map(p => {
+    const names = extractNamesFromBanking(p.banking_details)
+    return { project: p, names, keys: names.map(normalizedNameKey) }
+  })
+  const allKeys = Array.from(new Set(extracted.flatMap(e => e.keys))).filter(Boolean)
+
+  const approvedKeys = new Set<string>()
+  for (let i = 0; i < allKeys.length; i += 200) {
+    const chunk = allKeys.slice(i, i + 200)
+    const { data, error } = await supabase
+      .from('approved_beneficiaries')
+      .select('normalized_key')
+      .in('normalized_key', chunk)
+    if (error) throw error
+    for (const row of data || []) approvedKeys.add(row.normalized_key)
+  }
+
+  const rows = extracted.map(({ project, names, keys }) => {
+    const autoApproved = names.length > 0 && keys.every(k => approvedKeys.has(k))
+    return {
+      project_id: project.id,
+      names,
+      status: (autoApproved ? 'auto_approved' : 'pending_screening') as ScreeningStatus
+    }
+  })
+
+  const { error: insertError } = await supabase
+    .from('compliance_screenings')
+    .upsert(rows, { onConflict: 'project_id', ignoreDuplicates: true })
+  if (insertError) throw insertError
+
+  return { created: rows.length }
+}
+
+/**
+ * Sweep err_projects that have banking details but no screening yet and
+ * create screenings for them. Covers F1s created outside portal API routes
+ * (ERR App submissions, legacy client-side inserts) and acts as the backfill.
+ */
+export async function sweepUnscreenedProjects(
+  supabase: SupabaseClient
+): Promise<{ created: number }> {
+  const { data: screened, error: screenedError } = await supabase
+    .from('compliance_screenings')
+    .select('project_id')
+  if (screenedError) throw screenedError
+  const screenedIds = new Set((screened || []).map(r => r.project_id))
+
+  const unscreened: Array<{ id: string; banking_details: string | null }> = []
+  const pageSize = 1000
+  for (let start = 0; ; start += pageSize) {
+    const { data, error } = await supabase
+      .from('err_projects')
+      .select('id, banking_details, funding_status, status')
+      .not('banking_details', 'is', null)
+      .range(start, start + pageSize - 1)
+    if (error) throw error
+    const page = data || []
+    for (const row of page) {
+      // Committed F1s already passed the gate; declined/completed ones
+      // will never commit — don't queue either retroactively
+      if (row.funding_status === 'committed') continue
+      if (row.status === 'declined' || row.status === 'completed') continue
+      if (!screenedIds.has(row.id)) {
+        unscreened.push({ id: row.id, banking_details: row.banking_details })
+      }
+    }
+    if (page.length < pageSize) break
+  }
+
+  return ensureScreeningsForProjects(supabase, unscreened)
+}
+
+/**
+ * Return the subset of project ids that are blocked from committing.
+ *
+ * - sanctions_match: blocked until finance dismisses the flag as erroneous
+ * - missing_id: blocked until finance uploads an ID (approved) or dismisses the flag
+ * - legacy flagged rows with no flag_type: blocked until finance approves or dismisses
+ */
+export async function getComplianceBlockedProjectIds(
+  supabase: SupabaseClient,
+  projectIds: string[]
+): Promise<string[]> {
+  if (projectIds.length === 0) return []
+  const blocked: string[] = []
+  for (let i = 0; i < projectIds.length; i += 200) {
+    const chunk = projectIds.slice(i, i + 200)
+    const { data, error } = await supabase
+      .from('compliance_screenings')
+      .select('project_id, status, flag_type, finance_review_status')
+      .in('project_id', chunk)
+      .eq('status', 'flagged')
+    if (error) throw error
+    for (const row of data || []) {
+      const review = row.finance_review_status
+      // Dismissed as erroneous → not blocked
+      if (review === 'rejected') continue
+      if (row.flag_type === 'sanctions_match') {
+        // Payment must be stopped until the flag is dismissed
+        blocked.push(row.project_id)
+        continue
+      }
+      if (row.flag_type === 'missing_id') {
+        // Unblocked only after ID upload (approved)
+        if (review !== 'approved') blocked.push(row.project_id)
+        continue
+      }
+      // Legacy generic flag
+      if (review !== 'approved') blocked.push(row.project_id)
+    }
+  }
+  return blocked
+}

--- a/src/lib/complianceAlerts.ts
+++ b/src/lib/complianceAlerts.ts
@@ -1,0 +1,64 @@
+/**
+ * Best-effort Slack alert for sanctions-match flags.
+ * Uses SLACK_BOT_TOKEN. Optional COMPLIANCE_ALERT_SLACK_CHANNEL (e.g. C0123...).
+ * If no channel is configured, logs the alert payload and returns false.
+ */
+export async function sendSanctionsMatchAlert(payload: {
+  errId: string | null
+  projectId: string
+  names: string[]
+  note: string | null
+  screeningId: string
+}): Promise<{ sent: boolean; detail: string }> {
+  const token = process.env.SLACK_BOT_TOKEN
+  const channel = process.env.COMPLIANCE_ALERT_SLACK_CHANNEL
+
+  const text = [
+    ':rotating_light: *COMPLIANCE RED ALERT — PAYMENT MUST BE STOPPED*',
+    '',
+    `*F1 / ERR ID:* ${payload.errId || payload.projectId}`,
+    `*Payee names:* ${(payload.names || []).join(', ') || '—'}`,
+    `*Flag:* Potential Descartes / sanctions list match`,
+    payload.note ? `*Ahmed's note:* ${payload.note}` : null,
+    '',
+    '_Notify: Finance team, Ahmed, Yara, Josh, Nihal, Santiago_',
+    `_Screening ID: ${payload.screeningId}_`
+  ]
+    .filter(Boolean)
+    .join('\n')
+
+  if (!token) {
+    console.warn('[compliance-alert] SLACK_BOT_TOKEN not set; alert not sent to Slack')
+    console.warn('[compliance-alert]', text)
+    return { sent: false, detail: 'Slack token not configured — in-app alert only' }
+  }
+  if (!channel) {
+    console.warn('[compliance-alert] COMPLIANCE_ALERT_SLACK_CHANNEL not set; alert not sent to Slack')
+    console.warn('[compliance-alert]', text)
+    return { sent: false, detail: 'Slack channel not configured — in-app alert only' }
+  }
+
+  try {
+    const res = await fetch('https://slack.com/api/chat.postMessage', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        channel,
+        text,
+        unfurl_links: false
+      })
+    })
+    const data = await res.json()
+    if (!data.ok) {
+      console.error('[compliance-alert] Slack API error:', data.error)
+      return { sent: false, detail: `Slack error: ${data.error}` }
+    }
+    return { sent: true, detail: 'Slack alert sent' }
+  } catch (e) {
+    console.error('[compliance-alert] Failed to post to Slack:', e)
+    return { sent: false, detail: 'Slack request failed' }
+  }
+}


### PR DESCRIPTION
## Visual Compliance (OFAC / Descartes) screening for F1 payments

Implements the compliance workflow agreed after the demo: Ahmed screens F1 payee
names, raises typed flags, and finance resolves them before an F1 can be committed.

### 1. Three typed flags (from demo feedback)
- **Missing ID** — Ahmed flags an F1 with no ID. Finance can **upload the ID**
  (attached to the F1 via `err_projects.identity_document_file_key`) or **dismiss**
  the flag if it was raised in error.
- **Sanctions match** — potential Descartes/OFAC hit. Status becomes
  **PAYMENT STOPPED** (red), an in-app alert goes to Finance + Ahmed/Yara/Josh/
  Nihal/Santiago, and a Slack alert fires if `SLACK_BOT_TOKEN` /
  `COMPLIANCE_ALERT_SLACK_CHANNEL` are configured. Finance cannot clear it for
  payment — only dismiss if erroneous.
- Both flags block the F1 from F2 commit until resolved.

### 2. Approved-beneficiaries exception list
- One-time importer for the compliance officer's cleared-names list
  (`scripts/import-cleared-names.js`): parses EN + AR columns, upserts each into
  `approved_beneficiaries`, and reconciles against `err_projects.banking_details`
  to clear already-flagged/pending F1s for those payees. Dry-run by default;
  `--commit`, `--fuzzy` (subset match, ≥3 shared tokens, never auto-clears a typed
  sanctions_match).
- Names on the whitelist auto-approve during screening.

### 3. Screening / matching logic
- Background screening: pending screenings do **not** block commit; only flags do.
- **Matching stays per-language for now.** F1 banking details are single-language
  in the data (~1,556/1,603 English, 44 Arabic, only 2 with both), so a combined
  EN+AR key cannot be built at screening time — it would flag every payee for
  manual review.
- `combinedNameKey(en, ar)` is shipped in `src/lib/compliance.ts`, documented and
  ready to switch on once the F1 intake captures a structured English **and**
  Arabic beneficiary name (with a single-language fallback). See the note in that
  file for the rationale.

### Schema (already applied to live Supabase)
- `sql/create_compliance_screenings.sql` — `compliance_screenings`, `approved_beneficiaries`
- `sql/add_compliance_flag_types.sql` — `flag_type`, `alerted_at`, `err_projects.identity_document_file_key`

### Notes for review
- Stacked on `feat/fcdo-financial-f4-sync` so the diff is compliance-only.
- New permissions in `src/data/functions.json`: `compliance_view_page`,
  `compliance_screen`, `compliance_finance_review`.
- Without Slack env vars, sanctions alerts are in-app + console only.

### Test plan
- [ ] Flag Missing ID → finance uploads ID → F1 unblocked and ID attached
- [ ] Flag Missing ID → dismiss (erroneous) → F1 unblocked
- [ ] Flag Sanctions match → PAYMENT STOPPED, alert raised, commit blocked; dismiss works
- [ ] Import cleared names (dry-run then `--commit`) and confirm whitelist auto-approval
- [ ] F2 Uncommitted badges reflect status; blocked rows are non-selectable
