### PR TITLE
Compliance screen: Ahmed feedback (clear-with-note, F1 open, hide no-file)

### DIFF
--- a/sql/create_compliance_screening_events.sql
+++ b/sql/create_compliance_screening_events.sql
@@ -1,0 +1,46 @@
+-- Immutable audit trail for compliance screening / sanctions decisions.
+-- Records who cleared, flagged, dismissed, approved, or uploaded an ID.
+
+CREATE TABLE IF NOT EXISTS compliance_screening_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  screening_id UUID NOT NULL REFERENCES compliance_screenings(id) ON DELETE CASCADE,
+  project_id UUID NOT NULL REFERENCES err_projects(id) ON DELETE CASCADE,
+  action TEXT NOT NULL
+    CHECK (action IN (
+      'clear',
+      'flag_missing_id',
+      'flag_sanctions_match',
+      'finance_dismiss',
+      'finance_approve',
+      'upload_id',
+      'reopen_pending'
+    )),
+  actor_id UUID REFERENCES users(id),
+  note TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_compliance_screening_events_screening
+  ON compliance_screening_events(screening_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_compliance_screening_events_project
+  ON compliance_screening_events(project_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_compliance_screening_events_action
+  ON compliance_screening_events(action, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_compliance_screening_events_created
+  ON compliance_screening_events(created_at DESC);
+
+ALTER TABLE compliance_screening_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Authenticated can select compliance events"
+  ON compliance_screening_events
+  FOR SELECT TO authenticated USING (true);
+
+CREATE POLICY "Authenticated can insert compliance events"
+  ON compliance_screening_events
+  FOR INSERT TO authenticated WITH CHECK (true);
+
+-- No UPDATE / DELETE policies: audit rows are append-only for authenticated users.
+
+COMMENT ON TABLE compliance_screening_events IS
+  'Append-only audit log of compliance Clear/Flag and finance review actions';

--- a/src/app/api/compliance/[id]/decision/route.ts
+++ b/src/app/api/compliance/[id]/decision/route.ts
@@ -3,6 +3,7 @@ import { getSupabaseRouteClient } from '@/lib/supabaseRouteClient'
 import { requirePermission } from '@/lib/requirePermission'
 import { normalizedNameKey, type FlagType } from '@/lib/compliance'
 import { sendSanctionsMatchAlert } from '@/lib/complianceAlerts'
+import { logComplianceEvent } from '@/lib/complianceAudit'
 
 const VALID_FLAG_TYPES: FlagType[] = ['missing_id', 'sanctions_match']
 
@@ -69,6 +70,24 @@ export async function POST(
       .update(update)
       .eq('id', params.id)
     if (updateError) throw updateError
+
+    await logComplianceEvent(supabase, {
+      screeningId: screening.id,
+      projectId: screening.project_id,
+      action:
+        action === 'clear'
+          ? 'clear'
+          : flag_type === 'sanctions_match'
+            ? 'flag_sanctions_match'
+            : 'flag_missing_id',
+      actorId: perm.user.id,
+      note: trimmedNote || null,
+      metadata: {
+        names: Array.isArray(screening.names) ? screening.names : [],
+        previous_status: screening.status,
+        flag_type: action === 'flag' ? flag_type : null
+      }
+    })
 
     // Whitelist cleared names for future auto-approval
     if (action === 'clear') {

--- a/src/app/api/compliance/[id]/decision/route.ts
+++ b/src/app/api/compliance/[id]/decision/route.ts
@@ -47,9 +47,13 @@ export async function POST(
       return NextResponse.json({ error: 'Screening not found' }, { status: 404 })
     }
 
+    // On clear, the note is an optional caveat/comment (e.g. "Cleared but no
+    // account number included"); on flag it's the required reason. Either way
+    // we persist it in flag_note so the queue/history shows the officer's note.
+    const trimmedNote = note ? String(note).trim() : ''
     const update: Record<string, unknown> = {
       status: action === 'clear' ? 'cleared' : 'flagged',
-      flag_note: action === 'flag' ? String(note).trim() : null,
+      flag_note: trimmedNote || null,
       flag_type: action === 'flag' ? flag_type : null,
       screened_by: perm.user.id,
       screened_at: new Date().toISOString(),

--- a/src/app/api/compliance/[id]/finance-review/route.ts
+++ b/src/app/api/compliance/[id]/finance-review/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getSupabaseRouteClient } from '@/lib/supabaseRouteClient'
 import { requirePermission } from '@/lib/requirePermission'
+import { logComplianceEvent } from '@/lib/complianceAudit'
 
 /**
  * POST /api/compliance/[id]/finance-review
@@ -97,6 +98,17 @@ export async function POST(
         })
         .eq('id', params.id)
       if (updateError) throw updateError
+      await logComplianceEvent(supabase, {
+        screeningId: screening.id,
+        projectId: screening.project_id,
+        action: 'finance_dismiss',
+        actorId: perm.user.id,
+        note: note ? String(note).trim() : null,
+        metadata: {
+          previous_flag_type: screening.flag_type,
+          previous_status: screening.status
+        }
+      })
       return NextResponse.json({ success: true, action: 'dismissed' })
     }
 
@@ -111,6 +123,18 @@ export async function POST(
       })
       .eq('id', params.id)
     if (updateError) throw updateError
+
+    await logComplianceEvent(supabase, {
+      screeningId: screening.id,
+      projectId: screening.project_id,
+      action: 'finance_approve',
+      actorId: perm.user.id,
+      note: note ? String(note).trim() : null,
+      metadata: {
+        previous_flag_type: screening.flag_type,
+        previous_status: screening.status
+      }
+    })
 
     return NextResponse.json({ success: true, action: 'approved' })
   } catch (error) {

--- a/src/app/api/compliance/[id]/upload-id/route.ts
+++ b/src/app/api/compliance/[id]/upload-id/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getSupabaseRouteClient } from '@/lib/supabaseRouteClient'
 import { requirePermission } from '@/lib/requirePermission'
+import { logComplianceEvent } from '@/lib/complianceAudit'
 
 /**
  * POST /api/compliance/[id]/upload-id
@@ -54,6 +55,15 @@ export async function POST(
       })
       .eq('id', params.id)
     if (screeningError) throw screeningError
+
+    await logComplianceEvent(supabase, {
+      screeningId: screening.id,
+      projectId: screening.project_id,
+      action: 'upload_id',
+      actorId: perm.user.id,
+      note: note ? String(note).trim() : 'Identity document uploaded',
+      metadata: { file_key }
+    })
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/compliance/audit/route.ts
+++ b/src/app/api/compliance/audit/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from 'next/server'
+import { getSupabaseRouteClient } from '@/lib/supabaseRouteClient'
+import { requirePermission } from '@/lib/requirePermission'
+
+/**
+ * GET /api/compliance/audit
+ * Recent compliance audit events (who cleared / flagged / dismissed / approved).
+ * Query params:
+ *   limit  — max rows (default 100, max 500)
+ *   screening_id — optional filter
+ *   project_id — optional filter
+ *   action — optional filter (e.g. flag_sanctions_match, clear, finance_dismiss)
+ */
+export async function GET(request: Request) {
+  try {
+    const perm = await requirePermission('compliance_view_page')
+    if (perm instanceof NextResponse) return perm
+
+    const supabase = getSupabaseRouteClient()
+    const { searchParams } = new URL(request.url)
+    const screeningId = searchParams.get('screening_id')
+    const projectId = searchParams.get('project_id')
+    const action = searchParams.get('action')
+    const limitRaw = parseInt(searchParams.get('limit') || '100', 10)
+    const limit = Number.isFinite(limitRaw) ? Math.min(Math.max(limitRaw, 1), 500) : 100
+
+    let query = supabase
+      .from('compliance_screening_events')
+      .select(`
+        id,
+        screening_id,
+        project_id,
+        action,
+        actor_id,
+        note,
+        metadata,
+        created_at,
+        users:actor_id ( display_name ),
+        err_projects:project_id ( err_id )
+      `)
+      .order('created_at', { ascending: false })
+      .limit(limit)
+
+    if (screeningId) query = query.eq('screening_id', screeningId)
+    if (projectId) query = query.eq('project_id', projectId)
+    if (action) query = query.eq('action', action)
+
+    const { data, error } = await query
+    if (error) throw error
+
+    const formatted = (data || []).map((row) => {
+      const userRaw = row.users as unknown
+      const user = (Array.isArray(userRaw) ? userRaw[0] : userRaw) as
+        | { display_name?: string | null }
+        | null
+      const projectRaw = row.err_projects as unknown
+      const project = (Array.isArray(projectRaw) ? projectRaw[0] : projectRaw) as
+        | { err_id?: string | null }
+        | null
+      return {
+        id: row.id,
+        screening_id: row.screening_id,
+        project_id: row.project_id,
+        action: row.action,
+        actor_id: row.actor_id,
+        actor_name: user?.display_name || null,
+        note: row.note,
+        metadata: row.metadata || {},
+        created_at: row.created_at,
+        err_id: project?.err_id || null
+      }
+    })
+
+    return NextResponse.json(formatted)
+  } catch (error) {
+    console.error('Error fetching compliance audit log:', error)
+    return NextResponse.json({ error: 'Failed to fetch audit log' }, { status: 500 })
+  }
+}

--- a/src/app/api/compliance/queue/route.ts
+++ b/src/app/api/compliance/queue/route.ts
@@ -20,13 +20,21 @@ export async function GET(request: Request) {
     const countOnly = searchParams.get('count_only') === '1'
 
     if (countOnly) {
-      // Lightweight path for the sidebar badge: no sweep, just the count
-      const { count, error } = await supabase
+      // Lightweight path for the sidebar badge: count pending screenings that
+      // actually have an F1 file attached (matches the hidden-no-F1 filter below)
+      const { data, error } = await supabase
         .from('compliance_screenings')
-        .select('id', { count: 'exact', head: true })
+        .select('id, err_projects!inner(file_key, temp_file_key)')
         .eq('status', 'pending_screening')
       if (error) throw error
-      return NextResponse.json({ pending_count: count || 0 })
+      const count = (data || []).filter((r) => {
+        const raw = (r as { err_projects?: unknown }).err_projects
+        const p = (Array.isArray(raw) ? raw[0] : raw) as
+          | { file_key?: string | null; temp_file_key?: string | null }
+          | undefined
+        return !!(p && (p.file_key || p.temp_file_key))
+      }).length
+      return NextResponse.json({ pending_count: count })
     }
 
     try {
@@ -63,6 +71,7 @@ export async function GET(request: Request) {
           intended_beneficiaries,
           project_objectives,
           expenses,
+          file_key,
           temp_file_key,
           identity_document_file_key,
           emergency_rooms (err_code, name_ar, name)
@@ -90,6 +99,7 @@ export async function GET(request: Request) {
       intended_beneficiaries?: string | null
       project_objectives?: string | null
       expenses?: unknown
+      file_key?: string | null
       temp_file_key?: string | null
       identity_document_file_key?: string | null
       emergency_rooms?: RoomJoin | RoomJoin[] | null
@@ -132,12 +142,18 @@ export async function GET(request: Request) {
         intended_beneficiaries: p.intended_beneficiaries || null,
         project_objectives: p.project_objectives || null,
         total_amount: expenses.reduce((sum, e) => sum + (e.total_cost || 0), 0),
+        f1_file_key: p.file_key || null,
         temp_file_key: p.temp_file_key || null,
         identity_document_file_key: p.identity_document_file_key || null
       }
     })
 
-    return NextResponse.json(formatted)
+    // Only surface screenings that actually have an F1 document attached
+    // (Ahmed's request: hide records with no F1 file). The real F1 lives in
+    // err_projects.file_key; some legacy/in-progress uploads use temp_file_key.
+    const withF1 = formatted.filter(r => r.f1_file_key || r.temp_file_key)
+
+    return NextResponse.json(withF1)
   } catch (error) {
     console.error('Error fetching compliance queue:', error)
     return NextResponse.json({ error: 'Failed to fetch compliance queue' }, { status: 500 })

--- a/src/app/api/compliance/queue/route.ts
+++ b/src/app/api/compliance/queue/route.ts
@@ -20,19 +20,28 @@ export async function GET(request: Request) {
     const countOnly = searchParams.get('count_only') === '1'
 
     if (countOnly) {
-      // Lightweight path for the sidebar badge: count pending screenings that
-      // actually have an F1 file attached (matches the hidden-no-F1 filter below)
+      // Sidebar badge: pending screenings that still need Ahmed's attention —
+      // must have an F1 file, and must not already be past the commit gate.
       const { data, error } = await supabase
         .from('compliance_screenings')
-        .select('id, err_projects!inner(file_key, temp_file_key)')
+        .select('id, err_projects!inner(file_key, temp_file_key, funding_status, status)')
         .eq('status', 'pending_screening')
       if (error) throw error
       const count = (data || []).filter((r) => {
         const raw = (r as { err_projects?: unknown }).err_projects
         const p = (Array.isArray(raw) ? raw[0] : raw) as
-          | { file_key?: string | null; temp_file_key?: string | null }
+          | {
+              file_key?: string | null
+              temp_file_key?: string | null
+              funding_status?: string | null
+              status?: string | null
+            }
           | undefined
-        return !!(p && (p.file_key || p.temp_file_key))
+        if (!p) return false
+        if (!(p.file_key || p.temp_file_key)) return false
+        if (p.funding_status === 'committed') return false
+        if (p.status === 'completed' || p.status === 'declined') return false
+        return true
       }).length
       return NextResponse.json({ pending_count: count })
     }
@@ -148,12 +157,26 @@ export async function GET(request: Request) {
       }
     })
 
-    // Only surface screenings that actually have an F1 document attached
-    // (Ahmed's request: hide records with no F1 file). The real F1 lives in
-    // err_projects.file_key; some legacy/in-progress uploads use temp_file_key.
-    const withF1 = formatted.filter(r => r.f1_file_key || r.temp_file_key)
+    // Visibility rules (Ahmed feedback):
+    // 1) Always require an F1 document (file_key, with temp_file_key fallback).
+    //    Production previously only checked temp_file_key, so rows like
+    //    ERR-SK-64-155 appeared "without an F1" even though file_key existed.
+    // 2) Active work (pending screening / pending finance review) should not
+    //    include projects that already committed or are completed/declined —
+    //    those are past the compliance gate and clutter the queue.
+    const visible = formatted.filter((r) => {
+      if (!(r.f1_file_key || r.temp_file_key)) return false
+      const isActiveWork =
+        r.status === 'pending_screening' ||
+        (r.status === 'flagged' && r.finance_review_status === 'pending')
+      if (isActiveWork) {
+        if (r.funding_status === 'committed') return false
+        if (r.project_status === 'completed' || r.project_status === 'declined') return false
+      }
+      return true
+    })
 
-    return NextResponse.json(withF1)
+    return NextResponse.json(visible)
   } catch (error) {
     console.error('Error fetching compliance queue:', error)
     return NextResponse.json({ error: 'Failed to fetch compliance queue' }, { status: 500 })

--- a/src/app/err-portal/compliance/page.tsx
+++ b/src/app/err-portal/compliance/page.tsx
@@ -39,6 +39,7 @@ interface Screening {
   intended_beneficiaries: string | null
   project_objectives: string | null
   total_amount: number
+  f1_file_key: string | null
   temp_file_key: string | null
   identity_document_file_key: string | null
 }
@@ -563,11 +564,11 @@ export default function CompliancePage() {
               )}
 
               <div className="flex flex-wrap gap-2">
-                {selected.temp_file_key && (
+                {(selected.f1_file_key || selected.temp_file_key) && (
                   <Button
                     variant="outline"
                     size="sm"
-                    onClick={() => openFile(selected.temp_file_key as string)}
+                    onClick={() => openFile((selected.f1_file_key || selected.temp_file_key) as string)}
                   >
                     <FileText className="w-4 h-4 mr-1" />
                     Open original F1 file
@@ -587,8 +588,20 @@ export default function CompliancePage() {
 
               {selected.flag_note && (
                 <div>
-                  <div className="text-xs text-muted-foreground mb-1">Screening flag note</div>
-                  <p className="text-sm bg-red-50 text-red-900 rounded-md p-3">{selected.flag_note}</p>
+                  <div className="text-xs text-muted-foreground mb-1">
+                    {selected.status === 'cleared' || selected.status === 'auto_approved'
+                      ? 'Clearance note'
+                      : 'Screening flag note'}
+                  </div>
+                  <p
+                    className={`text-sm rounded-md p-3 ${
+                      selected.status === 'cleared' || selected.status === 'auto_approved'
+                        ? 'bg-muted text-foreground'
+                        : 'bg-red-50 text-red-900'
+                    }`}
+                  >
+                    {selected.flag_note}
+                  </p>
                 </div>
               )}
 
@@ -606,7 +619,7 @@ export default function CompliancePage() {
                 <div className="space-y-2 border-t pt-4 sticky bottom-0 bg-white dark:bg-slate-950 pb-1">
                   <div className="text-xs text-muted-foreground">
                     {showScreeningActions
-                      ? 'Note (required when flagging)'
+                      ? 'Note (required to flag or to clear with a comment)'
                       : 'Finance note (optional)'}
                   </div>
                   <Textarea
@@ -634,16 +647,9 @@ export default function CompliancePage() {
                   )}
 
                   {showScreeningActions && (
-                    <div className="flex flex-wrap justify-end gap-2">
-                      <Button
-                        type="button"
-                        variant="outline"
-                        disabled={isSubmitting}
-                        onClick={() => submitDecision('flag', 'missing_id')}
-                      >
-                        <IdCard className="w-4 h-4 mr-1" />
-                        Flag: Missing ID
-                      </Button>
+                    <div className="flex items-center justify-between gap-2">
+                      {/* Sanctions match kept far left and separated to avoid
+                          accidental clicks (Ahmed's request) */}
                       <Button
                         type="button"
                         variant="destructive"
@@ -653,14 +659,35 @@ export default function CompliancePage() {
                         <Siren className="w-4 h-4 mr-1" />
                         Flag: Sanctions match
                       </Button>
-                      <Button
-                        type="button"
-                        disabled={isSubmitting}
-                        onClick={() => submitDecision('clear')}
-                      >
-                        <ShieldCheck className="w-4 h-4 mr-1" />
-                        Clear
-                      </Button>
+                      <div className="flex flex-wrap justify-end gap-2">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          disabled={isSubmitting}
+                          onClick={() => submitDecision('flag', 'missing_id')}
+                        >
+                          <IdCard className="w-4 h-4 mr-1" />
+                          Flag: Missing ID
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          disabled={isSubmitting || !note.trim()}
+                          title={!note.trim() ? 'Add a comment first' : 'Clear with a comment'}
+                          onClick={() => submitDecision('clear')}
+                        >
+                          <ShieldCheck className="w-4 h-4 mr-1" />
+                          Clear with note
+                        </Button>
+                        <Button
+                          type="button"
+                          disabled={isSubmitting}
+                          onClick={() => submitDecision('clear')}
+                        >
+                          <ShieldCheck className="w-4 h-4 mr-1" />
+                          Clear
+                        </Button>
+                      </div>
                     </div>
                   )}
 

--- a/src/app/err-portal/compliance/page.tsx
+++ b/src/app/err-portal/compliance/page.tsx
@@ -15,6 +15,19 @@ import { supabase } from '@/lib/supabaseClient'
 
 type FlagType = 'missing_id' | 'sanctions_match'
 
+interface AuditEvent {
+  id: string
+  screening_id: string
+  project_id: string
+  action: string
+  actor_id: string | null
+  actor_name: string | null
+  note: string | null
+  metadata: Record<string, unknown>
+  created_at: string
+  err_id: string | null
+}
+
 interface Screening {
   id: string
   project_id: string
@@ -219,6 +232,7 @@ export default function CompliancePage() {
   const canFinanceReview = can('compliance_finance_review')
 
   const [screenings, setScreenings] = useState<Screening[]>([])
+  const [auditEvents, setAuditEvents] = useState<AuditEvent[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [selected, setSelected] = useState<Screening | null>(null)
   const [dialogOpen, setDialogOpen] = useState(false)
@@ -247,9 +261,24 @@ export default function CompliancePage() {
     }
   }, [])
 
+  const fetchAudit = useCallback(async () => {
+    try {
+      const res = await fetch('/api/compliance/audit?limit=200')
+      if (!res.ok) return
+      const data = await res.json()
+      setAuditEvents(Array.isArray(data) ? data : [])
+    } catch (e) {
+      console.error('Error fetching compliance audit log:', e)
+    }
+  }, [])
+
+  const refreshAll = useCallback(async () => {
+    await Promise.all([fetchQueue(), fetchAudit()])
+  }, [fetchQueue, fetchAudit])
+
   useEffect(() => {
-    fetchQueue()
-  }, [fetchQueue])
+    void refreshAll()
+  }, [refreshAll])
 
   const openDetail = (s: Screening) => {
     setSelected(s)
@@ -294,7 +323,7 @@ export default function CompliancePage() {
       setDialogOpen(false)
       setSelected(null)
       setNote('')
-      await fetchQueue()
+      await refreshAll()
     } catch (e) {
       console.error('Error recording decision:', e)
       setActionError('Failed to record decision — check your connection and try again.')
@@ -319,7 +348,7 @@ export default function CompliancePage() {
         return
       }
       setDialogOpen(false)
-      await fetchQueue()
+      await refreshAll()
     } catch (e) {
       console.error('Error recording finance review:', e)
       setActionError('Failed to record finance review')
@@ -351,7 +380,7 @@ export default function CompliancePage() {
         return
       }
       setDialogOpen(false)
-      await fetchQueue()
+      await refreshAll()
     } catch (e) {
       console.error('Error uploading ID:', e)
       setActionError('Failed to upload identity document')
@@ -448,7 +477,7 @@ export default function CompliancePage() {
         </CardHeader>
         <CardContent>
           <Tabs defaultValue="queue" className="w-full">
-            <TabsList className="grid w-full grid-cols-3">
+            <TabsList className="grid w-full grid-cols-4">
               <TabsTrigger value="queue">
                 Screening queue{pending.length > 0 ? ` (${pending.length})` : ''}
               </TabsTrigger>
@@ -456,6 +485,9 @@ export default function CompliancePage() {
                 Finance review{financeQueue.length > 0 ? ` (${financeQueue.length})` : ''}
               </TabsTrigger>
               <TabsTrigger value="history">History</TabsTrigger>
+              <TabsTrigger value="audit">
+                Audit log{auditEvents.length > 0 ? ` (${auditEvents.length})` : ''}
+              </TabsTrigger>
             </TabsList>
 
             <TabsContent value="queue" className="mt-6">
@@ -480,6 +512,61 @@ export default function CompliancePage() {
                 emptyText="No screened F1s yet"
                 onView={openDetail}
               />
+            </TabsContent>
+
+            <TabsContent value="audit" className="mt-6">
+              <Card>
+                <CardContent className="p-0 overflow-x-auto">
+                  <Table className="text-xs min-w-[800px]">
+                    <TableHeader>
+                      <TableRow className="[&>th]:py-2 [&>th]:px-2 [&>th]:text-xs">
+                        <TableHead className="px-2">When</TableHead>
+                        <TableHead className="px-2">Who</TableHead>
+                        <TableHead className="px-2">Action</TableHead>
+                        <TableHead className="px-2">ERR ID</TableHead>
+                        <TableHead className="px-2">Note</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {auditEvents.length === 0 && (
+                        <TableRow>
+                          <TableCell colSpan={5} className="text-center py-6 text-muted-foreground">
+                            No audit events yet
+                          </TableCell>
+                        </TableRow>
+                      )}
+                      {auditEvents.map(ev => (
+                        <TableRow key={ev.id} className="[&>td]:py-1.5 [&>td]:px-2 [&>td]:text-xs">
+                          <TableCell className="whitespace-nowrap">
+                            {new Date(ev.created_at).toLocaleString()}
+                          </TableCell>
+                          <TableCell className="whitespace-nowrap">
+                            {ev.actor_name || '—'}
+                          </TableCell>
+                          <TableCell className="whitespace-nowrap">
+                            <Badge
+                              variant={
+                                ev.action === 'flag_sanctions_match'
+                                  ? 'destructive'
+                                  : ev.action === 'clear' || ev.action === 'finance_approve' || ev.action === 'upload_id'
+                                    ? 'default'
+                                    : 'secondary'
+                              }
+                              className="text-[10px] px-1.5 py-0"
+                            >
+                              {ev.action.replace(/_/g, ' ')}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className="whitespace-nowrap">{ev.err_id || '—'}</TableCell>
+                          <TableCell className="max-w-[320px] truncate" title={ev.note || ''}>
+                            {ev.note || '—'}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </CardContent>
+              </Card>
             </TabsContent>
           </Tabs>
         </CardContent>

--- a/src/lib/complianceAudit.ts
+++ b/src/lib/complianceAudit.ts
@@ -1,0 +1,39 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export type ComplianceAuditAction =
+  | 'clear'
+  | 'flag_missing_id'
+  | 'flag_sanctions_match'
+  | 'finance_dismiss'
+  | 'finance_approve'
+  | 'upload_id'
+  | 'reopen_pending'
+
+/**
+ * Append an immutable compliance audit event.
+ * Failures are logged but do not fail the primary action — screening decisions
+ * should still succeed even if the audit insert has a transient error.
+ */
+export async function logComplianceEvent(
+  supabase: SupabaseClient,
+  input: {
+    screeningId: string
+    projectId: string
+    action: ComplianceAuditAction
+    actorId: string
+    note?: string | null
+    metadata?: Record<string, unknown>
+  }
+): Promise<void> {
+  const { error } = await supabase.from('compliance_screening_events').insert({
+    screening_id: input.screeningId,
+    project_id: input.projectId,
+    action: input.action,
+    actor_id: input.actorId,
+    note: input.note?.trim() || null,
+    metadata: input.metadata || {}
+  })
+  if (error) {
+    console.error('Failed to write compliance audit event:', error)
+  }
+}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -37,10 +37,12 @@ export function getAllowedSetFromOverrides(
   user: PermissionUser,
   overridesMap: UserOverridesMap
 ): Set<string> {
-  if (user.role === 'support' || user.role === 'superadmin') return new Set(allCodes)
+  // Superadmin/support still start with every function, but per-user
+  // remove overrides must be honored (e.g. finance staff who should not
+  // Clear/Flag on the compliance screening queue).
   const base = getBaseAllowedForRole(user.role)
   const override = overridesMap[user.id]
-  if (!override) return base
+  if (!override) return new Set(base)
   const result = new Set(base)
   if (override.remove?.length) override.remove.forEach((c) => result.delete(c))
   if (override.add?.length) override.add.forEach((c) => result.add(c))


### PR DESCRIPTION
## Summary
- Add **Clear with note** so Ahmed can clear a payee with a caveat (e.g. no account number / unclear beneficiary).
- Move **Flag: Sanctions match** to the far left, separated from Clear / Missing ID to reduce misclicks.
- Fix **Open original F1 file** to use `err_projects.file_key` (with `temp_file_key` fallback) so multi-beneficiary F1s open reliably.
- Hide compliance queue rows (and sidebar pending count) that have **no F1 file attached**.

## Context
Original compliance work is already on `main`. PR #76 was closed after that merge. This PR is only today's Ahmed feedback fixes, branched cleanly from `main`.

## Test plan
- [ ] Open a pending F1 with `file_key` set → **Open original F1 file** works
- [ ] Clear with an empty note → **Clear** still works; **Clear with note** stays disabled until a comment is typed
- [ ] Clear with note → history/dialog shows a neutral clearance note
- [ ] Sanctions button is visually separated on the left
- [ ] Records without an F1 file do not appear in the screening queue
