### PR TITLE
Add Data Archive export for completed microgrants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@supabase/auth-helpers-nextjs": "^0.10.0",
         "@supabase/supabase-js": "^2.49.4",
         "@types/papaparse": "^5.3.15",
+        "archiver": "^7.0.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -50,6 +51,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
+        "@types/archiver": "^6.0.4",
         "@types/estree": "^1.0.7",
         "@types/json-schema": "^7.0.15",
         "@types/node": "^20",
@@ -468,6 +470,96 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@js-sdsl/ordered-map": {
@@ -1054,6 +1146,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -2788,6 +2890,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/archiver": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.4.tgz",
+      "integrity": "sha512-ULdQpARQ3sz9WH4nb98mJDYA0ft2A8C4f4fovvUcFwINa1cgGjY36JCAYuP5YypRq4mco1lJp1/7jEMS2oR0Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/readdir-glob": "*"
+      }
+    },
     "node_modules/@types/caseless": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
@@ -2939,6 +3051,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/readdir-glob": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
+      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/request": {
@@ -3595,6 +3717,74 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3807,6 +3997,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -3875,8 +4071,101 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-stream/node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.6.tgz",
+      "integrity": "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
     },
     "node_modules/base64-arraybuffer": {
       "version": "1.0.2",
@@ -3956,6 +4245,39 @@
       },
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -4209,6 +4531,38 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/compress-commons/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4246,11 +4600,39 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4649,6 +5031,12 @@
       "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
       "license": "ISC"
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -4662,7 +5050,6 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
@@ -5331,6 +5718,24 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -5354,6 +5759,12 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -5523,6 +5934,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/form-data": {
@@ -5732,6 +6159,27 @@
       "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
       "license": "MIT"
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -5743,6 +6191,30 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -6163,6 +6635,26 @@
           "optional": true
         }
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -6697,7 +7189,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -6725,6 +7216,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jiti": {
@@ -6951,6 +7457,54 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/levn": {
@@ -7231,6 +7785,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -7272,6 +7832,12 @@
         "option": "~0.2.1",
         "underscore": "^1.13.1"
       }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/lucide-react": {
       "version": "0.487.0",
@@ -7423,6 +7989,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -7584,6 +8159,15 @@
       "integrity": "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -7820,6 +8404,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -7868,7 +8458,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7880,6 +8469,22 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/pbf": {
       "version": "4.0.1",
@@ -7985,6 +8590,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -8310,6 +8924,36 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/recharts": {
@@ -8714,7 +9358,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -8727,7 +9370,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8803,6 +9445,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/sort-asc": {
@@ -8944,6 +9598,17 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -8966,6 +9631,27 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/string-width/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -9087,6 +9773,19 @@
       }
     },
     "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -9222,6 +9921,32 @@
         "node": ">=6"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/teeny-request": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
@@ -9279,6 +10004,38 @@
       },
       "peerDependenciesMeta": {
         "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-decoder/node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
           "optional": true
         }
       }
@@ -9759,7 +10516,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -9905,6 +10661,24 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -10009,6 +10783,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/zip-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/supabase-js": "^2.49.4",
     "@types/papaparse": "^5.3.15",
+    "archiver": "^7.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
@@ -51,6 +52,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@types/archiver": "^6.0.4",
     "@types/estree": "^1.0.7",
     "@types/json-schema": "^7.0.15",
     "@types/node": "^20",

--- a/sql/add_completed_at_to_err_projects.sql
+++ b/sql/add_completed_at_to_err_projects.sql
@@ -1,0 +1,7 @@
+-- Data Archive feature: record when a project was marked completed.
+-- Run in Supabase SQL Editor.
+
+ALTER TABLE err_projects
+  ADD COLUMN IF NOT EXISTS completed_at timestamptz;
+
+COMMENT ON COLUMN err_projects.completed_at IS 'When status was set to completed (used by Data Archive exports). NULL for legacy completions until amended.';

--- a/src/app/api/data-archive/completed/route.ts
+++ b/src/app/api/data-archive/completed/route.ts
@@ -1,0 +1,117 @@
+import { NextResponse } from 'next/server'
+import { getSupabaseRouteClient } from '@/lib/supabaseRouteClient'
+import { requirePermission } from '@/lib/requirePermission'
+import { collectArchiveFiles, type ArchiveProjectRow } from '@/lib/dataArchive'
+
+const PROJECT_SELECT = `
+  id,
+  grant_id,
+  grant_serial_id,
+  state,
+  completed_at,
+  file_key,
+  approval_file_key,
+  mou_id,
+  donor_id,
+  grant_call_id,
+  emergency_rooms ( err_code, name ),
+  donors ( id, name, short_name ),
+  grant_calls ( id, name, shortname )
+`
+
+/** Resolve month=YYYY-MM or from/to (inclusive dates) into an ISO [start, end) range. */
+function resolveRange(url: URL): { start: string; end: string } | null {
+  const month = url.searchParams.get('month')
+  if (month && /^\d{4}-\d{2}$/.test(month)) {
+    const [y, m] = month.split('-').map(Number)
+    const start = new Date(Date.UTC(y, m - 1, 1))
+    const end = new Date(Date.UTC(y, m, 1))
+    return { start: start.toISOString(), end: end.toISOString() }
+  }
+  const from = url.searchParams.get('from')
+  const to = url.searchParams.get('to')
+  if (from && to) {
+    const start = new Date(`${from}T00:00:00.000Z`)
+    const endExclusive = new Date(`${to}T00:00:00.000Z`)
+    endExclusive.setUTCDate(endExclusive.getUTCDate() + 1)
+    if (!isNaN(start.getTime()) && !isNaN(endExclusive.getTime())) {
+      return { start: start.toISOString(), end: endExclusive.toISOString() }
+    }
+  }
+  return null
+}
+
+export async function GET(req: Request) {
+  const perm = await requirePermission('data_archive_view_page')
+  if (perm instanceof NextResponse) return perm
+
+  try {
+    const supabase = getSupabaseRouteClient()
+    const url = new URL(req.url)
+    const range = resolveRange(url)
+    const includeUndated = url.searchParams.get('include_undated') === 'true'
+    const donorId = url.searchParams.get('donor_id')
+    const grantCallId = url.searchParams.get('grant_call_id')
+
+    let query = supabase
+      .from('err_projects')
+      .select(PROJECT_SELECT)
+      .eq('status', 'completed')
+
+    if (range) {
+      if (includeUndated) {
+        query = query.or(
+          `and(completed_at.gte.${range.start},completed_at.lt.${range.end}),completed_at.is.null`
+        )
+      } else {
+        query = query.gte('completed_at', range.start).lt('completed_at', range.end)
+      }
+    }
+    if (donorId) query = query.eq('donor_id', donorId)
+    if (grantCallId) query = query.eq('grant_call_id', grantCallId)
+
+    const { data: projects, error } = await query.order('completed_at', {
+      ascending: false,
+      nullsFirst: false
+    })
+    if (error) throw error
+
+    const files = await collectArchiveFiles(supabase, (projects || []) as unknown as ArchiveProjectRow[])
+
+    const rows = (projects || []).map((p: any) => {
+      const projectFiles = files[p.id] || []
+      const has = (form: string, nameStartsWith: string) =>
+        projectFiles.some((f) => f.form === form && f.name.startsWith(nameStartsWith) && !!f.storage_path)
+      const count = (form: string) => projectFiles.filter((f) => f.form === form && !!f.storage_path).length
+      return {
+        id: p.id,
+        grant_id: p.grant_id || null,
+        grant_serial_id: p.grant_serial_id || null,
+        state: p.state || null,
+        completed_at: p.completed_at || null,
+        err_code: p.emergency_rooms?.err_code || null,
+        err_name: p.emergency_rooms?.name || null,
+        donor_id: p.donors?.id || p.donor_id || null,
+        donor_name: p.donors?.name || null,
+        donor_short_name: p.donors?.short_name || null,
+        grant_call_id: p.grant_calls?.id || p.grant_call_id || null,
+        grant_call_name: p.grant_calls?.name || null,
+        grant_call_shortname: p.grant_calls?.shortname || null,
+        files: {
+          f1: has('F1', 'F1_workplan'),
+          f2: has('F2', 'F2_approval'),
+          f3_mou: has('F3', 'F3_MOU.'),
+          f3_signed: has('F3', 'F3_MOU_signed'),
+          payment_confirmation: has('F3', 'F3_payment_confirmation'),
+          f4_count: count('F4'),
+          f5_count: count('F5')
+        }
+      }
+    })
+
+    return NextResponse.json({ rows })
+  } catch (e) {
+    console.error('[data-archive/completed] error', e)
+    return NextResponse.json({ error: 'Failed to load completed projects' }, { status: 500 })
+  }
+}

--- a/src/app/api/data-archive/export/route.ts
+++ b/src/app/api/data-archive/export/route.ts
@@ -1,0 +1,155 @@
+import { NextResponse } from 'next/server'
+import { PassThrough, Readable } from 'stream'
+import archiver from 'archiver'
+import { requirePermission } from '@/lib/requirePermission'
+import { getSupabaseAdmin } from '@/lib/supabaseAdmin'
+import { collectArchiveFiles, safeName, type ArchiveProjectRow } from '@/lib/dataArchive'
+
+export const runtime = 'nodejs'
+export const maxDuration = 300
+
+const MAX_PROJECTS_PER_EXPORT = 500
+
+function csvCell(value: string | null | undefined): string {
+  const s = value == null ? '' : String(value)
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
+}
+
+function monthFolder(completedAt: string | null): string {
+  if (!completedAt) return 'undated'
+  const d = new Date(completedAt)
+  if (isNaN(d.getTime())) return 'undated'
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`
+}
+
+export async function POST(req: Request) {
+  const perm = await requirePermission('data_archive_download')
+  if (perm instanceof NextResponse) return perm
+
+  let projectIds: string[]
+  try {
+    const body = await req.json()
+    projectIds = Array.isArray(body?.project_ids) ? body.project_ids.filter((id: unknown) => typeof id === 'string') : []
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+  }
+  if (!projectIds.length) {
+    return NextResponse.json({ error: 'project_ids is required' }, { status: 400 })
+  }
+  if (projectIds.length > MAX_PROJECTS_PER_EXPORT) {
+    return NextResponse.json(
+      { error: `Too many projects in one export (max ${MAX_PROJECTS_PER_EXPORT}). Narrow the period or grant filter.` },
+      { status: 400 }
+    )
+  }
+
+  const supabase = getSupabaseAdmin()
+
+  const projects: any[] = []
+  for (let i = 0; i < projectIds.length; i += 80) {
+    const { data, error } = await supabase
+      .from('err_projects')
+      .select(`
+        id,
+        grant_id,
+        grant_serial_id,
+        state,
+        status,
+        completed_at,
+        file_key,
+        approval_file_key,
+        mou_id,
+        emergency_rooms ( err_code, name ),
+        donors ( name, short_name ),
+        grant_calls ( name, shortname )
+      `)
+      .in('id', projectIds.slice(i, i + 80))
+      .eq('status', 'completed')
+    if (error) {
+      console.error('[data-archive/export] project fetch failed', error)
+      return NextResponse.json({ error: 'Failed to load projects' }, { status: 500 })
+    }
+    projects.push(...(data || []))
+  }
+  if (!projects.length) {
+    return NextResponse.json({ error: 'No completed projects found for the given ids' }, { status: 404 })
+  }
+
+  const filesByProject = await collectArchiveFiles(supabase, projects as unknown as ArchiveProjectRow[])
+  const exportedAt = new Date().toISOString()
+
+  const archive = archiver('zip', { zlib: { level: 6 } })
+  const pass = new PassThrough()
+  archive.on('warning', (err: unknown) => console.warn('[data-archive/export] archiver warning', err))
+  archive.on('error', (err: Error) => {
+    console.error('[data-archive/export] archiver error', err)
+    pass.destroy(err)
+  })
+  archive.pipe(pass)
+
+  // Fill the archive asynchronously while the response streams.
+  ;(async () => {
+    for (const p of projects) {
+      const donorLabel = p.donors?.short_name || p.donors?.name || 'Unknown-Donor'
+      const grantLabel = p.grant_calls?.shortname || p.grant_calls?.name || null
+      const grantFolder = safeName(grantLabel ? `${donorLabel} - ${grantLabel}` : donorLabel)
+      const serialFolder = safeName(p.grant_id || p.grant_serial_id || p.id)
+      const folder = `${monthFolder(p.completed_at)}/${grantFolder}/${serialFolder}`
+
+      const manifestRows: string[] = [
+        ['form', 'file_name', 'original_storage_path', 'status', 'grant_id', 'err_code', 'err_name', 'state', 'completed_at', 'exported_at']
+          .join(',')
+      ]
+
+      for (const f of filesByProject[p.id] || []) {
+        let status = 'MISSING'
+        if (f.storage_path) {
+          try {
+            const { data, error } = await supabase.storage.from('images').download(f.storage_path)
+            if (error || !data) {
+              status = 'DOWNLOAD_FAILED'
+              console.warn('[data-archive/export] download failed', f.storage_path, error)
+            } else {
+              archive.append(Buffer.from(await data.arrayBuffer()), { name: `${folder}/${f.name}` })
+              status = 'INCLUDED'
+            }
+          } catch (e) {
+            status = 'DOWNLOAD_FAILED'
+            console.warn('[data-archive/export] download threw', f.storage_path, e)
+          }
+        }
+        manifestRows.push(
+          [
+            f.form,
+            f.name,
+            f.storage_path || '',
+            status,
+            p.grant_id || p.grant_serial_id || '',
+            p.emergency_rooms?.err_code || '',
+            p.emergency_rooms?.name || '',
+            p.state || '',
+            p.completed_at || '',
+            exportedAt
+          ].map(csvCell).join(',')
+        )
+      }
+
+      // UTF-8 BOM so Arabic text opens correctly in Excel
+      archive.append('\uFEFF' + manifestRows.join('\n'), { name: `${folder}/_manifest.csv` })
+    }
+    await archive.finalize()
+  })().catch((err) => {
+    console.error('[data-archive/export] stream fill failed', err)
+    archive.abort()
+    pass.destroy(err instanceof Error ? err : new Error(String(err)))
+  })
+
+  const filename = `data-archive-${exportedAt.slice(0, 10)}.zip`
+  return new Response(Readable.toWeb(pass) as unknown as ReadableStream, {
+    headers: {
+      'Content-Type': 'application/zip',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+      'Cache-Control': 'no-store'
+    }
+  })
+}

--- a/src/app/api/overview/rollup/route.ts
+++ b/src/app/api/overview/rollup/route.ts
@@ -241,7 +241,7 @@ export async function GET(request: Request) {
     // Build project filter (include more statuses to catch F5 projects and completed projects)
     let projectQuery = supabase
       .from('err_projects')
-      .select('id, state, grant_call_id, grant_grid_id, grant_id, grant_segment, emergency_rooms (id, name, name_ar, err_code), planned_activities, expenses, source, status, funding_status, mou_id, f4_status, f5_status, date, date_transfer')
+      .select('id, state, grant_call_id, grant_grid_id, grant_id, grant_segment, emergency_rooms (id, name, name_ar, err_code), planned_activities, expenses, source, status, funding_status, mou_id, f4_status, f5_status, date, date_transfer, completed_at')
       .in('status', ['approved', 'active', 'pending', 'completed'])
       .in('funding_status', ['committed', 'allocated'])
 
@@ -468,6 +468,7 @@ export async function GET(request: Request) {
         portal_f5_count: f5Agg.count, // For portal projects, all F5s are portal F5s
         last_f5_date: f5Agg.last,
         status: p.status || null,
+        completed_at: p.completed_at || null,
         is_historical: false,
         f4_status,
         f5_status,

--- a/src/app/api/projects/[id]/status/route.ts
+++ b/src/app/api/projects/[id]/status/route.ts
@@ -33,10 +33,14 @@ export async function PATCH(
       return NextResponse.json({ error: 'Project not found' }, { status: 404 })
     }
 
-    // Update the project status
+    // Update the project status, tracking when it was marked completed
+    const newStatus = status || 'completed'
     const { error: updateError } = await supabase
       .from('err_projects')
-      .update({ status: status || 'completed' })
+      .update({
+        status: newStatus,
+        completed_at: newStatus === 'completed' ? new Date().toISOString() : null
+      })
       .eq('id', projectId)
 
     if (updateError) {

--- a/src/app/err-portal/data-archive/page.tsx
+++ b/src/app/err-portal/data-archive/page.tsx
@@ -1,0 +1,388 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAllowedFunctions } from '@/hooks/useAllowedFunctions'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Archive, Download, RefreshCw } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface ArchiveRow {
+  id: string
+  grant_id: string | null
+  grant_serial_id: string | null
+  state: string | null
+  completed_at: string | null
+  err_code: string | null
+  err_name: string | null
+  donor_id: string | null
+  donor_name: string | null
+  donor_short_name: string | null
+  grant_call_id: string | null
+  grant_call_name: string | null
+  grant_call_shortname: string | null
+  files: {
+    f1: boolean
+    f2: boolean
+    f3_mou: boolean
+    f3_signed: boolean
+    payment_confirmation: boolean
+    f4_count: number
+    f5_count: number
+  }
+}
+
+type PeriodMode = 'month' | 'range' | 'all'
+
+function previousMonth(): string {
+  const d = new Date()
+  d.setUTCDate(1)
+  d.setUTCMonth(d.getUTCMonth() - 1)
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`
+}
+
+function FileBadge({ label, present }: { label: string; present: boolean }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium border',
+        present
+          ? 'bg-green-50 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-400 dark:border-green-800'
+          : 'bg-red-50 text-red-600 border-red-200 dark:bg-red-900/30 dark:text-red-400 dark:border-red-800'
+      )}
+      title={present ? `${label} document available` : `${label} document missing`}
+    >
+      {label}
+    </span>
+  )
+}
+
+export default function DataArchivePage() {
+  const router = useRouter()
+  const { can, isLoading: permissionsLoading } = useAllowedFunctions()
+  const canViewPage = can('data_archive_view_page')
+  const canDownload = can('data_archive_download')
+
+  useEffect(() => {
+    if (!permissionsLoading && !canViewPage) {
+      router.replace('/err-portal')
+    }
+  }, [permissionsLoading, canViewPage, router])
+
+  const [periodMode, setPeriodMode] = useState<PeriodMode>('month')
+  const [month, setMonth] = useState<string>(previousMonth())
+  const [fromDate, setFromDate] = useState<string>('')
+  const [toDate, setToDate] = useState<string>('')
+  const [includeUndated, setIncludeUndated] = useState(false)
+  const [donorFilter, setDonorFilter] = useState<string>('all')
+
+  const [loading, setLoading] = useState(false)
+  const [rows, setRows] = useState<ArchiveRow[]>([])
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [exporting, setExporting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const loadRows = useCallback(async () => {
+    if (periodMode === 'month' && !month) return
+    if (periodMode === 'range' && (!fromDate || !toDate)) return
+    setLoading(true)
+    setError(null)
+    try {
+      const params = new URLSearchParams()
+      if (periodMode === 'month') params.set('month', month)
+      if (periodMode === 'range') {
+        params.set('from', fromDate)
+        params.set('to', toDate)
+      }
+      if (periodMode !== 'all' && includeUndated) params.set('include_undated', 'true')
+      const res = await fetch(`/api/data-archive/completed?${params.toString()}`)
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error(j.error || 'Failed to load completed projects')
+      }
+      const j = await res.json()
+      setRows(j.rows || [])
+      setSelected(new Set())
+    } catch (e: any) {
+      console.error(e)
+      setError(e.message || 'Failed to load completed projects')
+      setRows([])
+    } finally {
+      setLoading(false)
+    }
+  }, [periodMode, month, fromDate, toDate, includeUndated])
+
+  useEffect(() => {
+    if (!permissionsLoading && canViewPage) loadRows()
+  }, [permissionsLoading, canViewPage, loadRows])
+
+  const donorOptions = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const r of rows) {
+      if (r.donor_id) map.set(r.donor_id, r.donor_short_name || r.donor_name || r.donor_id)
+    }
+    return Array.from(map.entries()).sort((a, b) => a[1].localeCompare(b[1]))
+  }, [rows])
+
+  const filteredRows = useMemo(() => {
+    if (donorFilter === 'all') return rows
+    return rows.filter((r) => r.donor_id === donorFilter)
+  }, [rows, donorFilter])
+
+  const allSelected = filteredRows.length > 0 && filteredRows.every((r) => selected.has(r.id))
+
+  const toggleAll = () => {
+    if (allSelected) {
+      setSelected(new Set())
+    } else {
+      setSelected(new Set(filteredRows.map((r) => r.id)))
+    }
+  }
+
+  const toggleRow = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const runExport = async (projectIds: string[]) => {
+    if (!projectIds.length) return
+    setExporting(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/data-archive/export', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ project_ids: projectIds })
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error(j.error || 'Export failed')
+      }
+      const blob = await res.blob()
+      const disposition = res.headers.get('Content-Disposition') || ''
+      const match = disposition.match(/filename="([^"]+)"/)
+      const filename = match?.[1] || `data-archive-${new Date().toISOString().slice(0, 10)}.zip`
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = filename
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      URL.revokeObjectURL(url)
+    } catch (e: any) {
+      console.error(e)
+      setError(e.message || 'Export failed')
+    } finally {
+      setExporting(false)
+    }
+  }
+
+  const formatDate = (iso: string | null) =>
+    iso ? new Date(iso).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' }) : '—'
+
+  if (permissionsLoading || !canViewPage) return null
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold flex items-center gap-2">
+          <Archive className="h-7 w-7" />
+          Data Archive
+        </h1>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Export period</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap items-end gap-4">
+            <div className="space-y-1.5">
+              <Label className="text-sm">Period</Label>
+              <Select value={periodMode} onValueChange={(v) => setPeriodMode(v as PeriodMode)}>
+                <SelectTrigger className="h-9 w-40">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="month">Month</SelectItem>
+                  <SelectItem value="range">Custom range</SelectItem>
+                  <SelectItem value="all">All completed</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            {periodMode === 'month' && (
+              <div className="space-y-1.5">
+                <Label className="text-sm">Month</Label>
+                <Input type="month" className="h-9 w-44" value={month} onChange={(e) => setMonth(e.target.value)} />
+              </div>
+            )}
+            {periodMode === 'range' && (
+              <>
+                <div className="space-y-1.5">
+                  <Label className="text-sm">From</Label>
+                  <Input type="date" className="h-9 w-40" value={fromDate} onChange={(e) => setFromDate(e.target.value)} />
+                </div>
+                <div className="space-y-1.5">
+                  <Label className="text-sm">To</Label>
+                  <Input type="date" className="h-9 w-40" value={toDate} onChange={(e) => setToDate(e.target.value)} />
+                </div>
+              </>
+            )}
+            <div className="space-y-1.5">
+              <Label className="text-sm">Backdonor grant</Label>
+              <Select value={donorFilter} onValueChange={setDonorFilter}>
+                <SelectTrigger className="h-9 w-52">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All donors</SelectItem>
+                  {donorOptions.map(([id, label]) => (
+                    <SelectItem key={id} value={id}>{label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            {periodMode !== 'all' && (
+              <div className="flex items-center gap-2 pb-2">
+                <Checkbox
+                  id="include-undated"
+                  checked={includeUndated}
+                  onCheckedChange={(v) => setIncludeUndated(v === true)}
+                />
+                <Label htmlFor="include-undated" className="text-sm cursor-pointer">
+                  Include projects without a completion date
+                </Label>
+              </div>
+            )}
+            <div className="pb-0.5">
+              <Button variant="outline" size="sm" onClick={loadRows} disabled={loading}>
+                <RefreshCw className={cn('h-4 w-4 mr-2', loading && 'animate-spin')} />
+                Refresh
+              </Button>
+            </div>
+          </div>
+          <p className="text-xs text-muted-foreground mt-3">
+            Only microgrants marked as completed are available for export. Files are organized as
+            Month (YYYY-MM) &gt; Backdonor Grant &gt; Serial Number, with a manifest recording original
+            file locations and completion metadata in each folder.
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-base">
+              Completed microgrants
+              <span className="ml-2 text-sm font-normal text-muted-foreground">
+                {filteredRows.length} project{filteredRows.length === 1 ? '' : 's'}
+                {selected.size > 0 ? ` · ${selected.size} selected` : ''}
+              </span>
+            </CardTitle>
+            {canDownload && (
+              <div className="flex items-center gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={exporting || selected.size === 0}
+                  onClick={() => runExport(Array.from(selected))}
+                >
+                  <Download className={cn('h-4 w-4 mr-2', exporting && 'animate-pulse')} />
+                  Export selected
+                </Button>
+                <Button
+                  size="sm"
+                  disabled={exporting || filteredRows.length === 0}
+                  onClick={() => runExport(filteredRows.map((r) => r.id))}
+                >
+                  <Download className={cn('h-4 w-4 mr-2', exporting && 'animate-pulse')} />
+                  {exporting ? 'Preparing zip…' : 'Export all'}
+                </Button>
+              </div>
+            )}
+          </div>
+          {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="py-8 text-center text-muted-foreground">Loading…</div>
+          ) : (
+            <div className="overflow-x-auto w-full">
+              <Table className="min-w-[900px] text-xs [&_th]:py-1.5 [&_td]:py-1.5 [&_th]:px-2 [&_td]:px-2">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-8">
+                      <Checkbox checked={allSelected} onCheckedChange={toggleAll} aria-label="Select all" />
+                    </TableHead>
+                    <TableHead className="whitespace-nowrap">Serial Number</TableHead>
+                    <TableHead className="whitespace-nowrap">Backdonor Grant</TableHead>
+                    <TableHead className="whitespace-nowrap">ERR</TableHead>
+                    <TableHead className="whitespace-nowrap">State</TableHead>
+                    <TableHead className="whitespace-nowrap">Completed</TableHead>
+                    <TableHead className="whitespace-nowrap">Files</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredRows.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={7} className="text-center text-muted-foreground py-6">
+                        No completed microgrants found for this period.
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    filteredRows.map((r) => (
+                      <TableRow key={r.id} className="cursor-pointer hover:bg-muted/50" onClick={() => toggleRow(r.id)}>
+                        <TableCell onClick={(e) => e.stopPropagation()}>
+                          <Checkbox
+                            checked={selected.has(r.id)}
+                            onCheckedChange={() => toggleRow(r.id)}
+                            aria-label={`Select ${r.grant_id || r.id}`}
+                          />
+                        </TableCell>
+                        <TableCell className="font-medium whitespace-nowrap">
+                          {r.grant_id || r.grant_serial_id || '—'}
+                        </TableCell>
+                        <TableCell className="whitespace-nowrap">
+                          {r.donor_short_name || r.donor_name || '—'}
+                          {r.grant_call_shortname || r.grant_call_name ? (
+                            <span className="text-muted-foreground"> · {r.grant_call_shortname || r.grant_call_name}</span>
+                          ) : null}
+                        </TableCell>
+                        <TableCell className="whitespace-nowrap">{r.err_code || r.err_name || '—'}</TableCell>
+                        <TableCell className="whitespace-nowrap">{r.state || '—'}</TableCell>
+                        <TableCell className="whitespace-nowrap" title={r.completed_at || 'No completion date recorded'}>
+                          {formatDate(r.completed_at)}
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex flex-wrap gap-1">
+                            <FileBadge label="F1" present={r.files.f1} />
+                            <FileBadge label="F2" present={r.files.f2} />
+                            <FileBadge label="F3" present={r.files.f3_mou || r.files.f3_signed} />
+                            <FileBadge label="Pay" present={r.files.payment_confirmation} />
+                            <FileBadge label={`F4${r.files.f4_count > 1 ? ` (${r.files.f4_count})` : ''}`} present={r.files.f4_count > 0} />
+                            <FileBadge label={`F5${r.files.f5_count > 1 ? ` (${r.files.f5_count})` : ''}`} present={r.files.f5_count > 0} />
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/err-portal/layout.tsx
+++ b/src/app/err-portal/layout.tsx
@@ -7,7 +7,7 @@ import PageExplainerHeader from '@/components/layout/PageExplainerHeader'
 import { PageExplainerProvider } from '@/contexts/PageExplainerContext'
 import type { SidebarItem, SidebarLinkItem } from '@/components/layout/Sidebar'
 import { useRouter } from 'next/navigation'
-import { Users, ClipboardList, BarChart2, BarChart3, PieChart, UserCog, Home, CheckSquare, BookOpen, PenTool, Cog, FileText, BookMarked, Ticket, ShieldCheck } from 'lucide-react'
+import { Users, ClipboardList, BarChart2, BarChart3, PieChart, UserCog, Home, CheckSquare, BookOpen, PenTool, Cog, FileText, BookMarked, Ticket, ShieldCheck, Archive } from 'lucide-react'
 import { supabase } from '@/lib/supabaseClient'
 import { useAllowedFunctions } from '@/hooks/useAllowedFunctions'
 
@@ -91,6 +91,7 @@ export default function ErrPortalLayout({
   const canViewDashboard = can('dashboard_view_page')
   const canViewSurveys = can('surveys_view_page')
   const canRaiseTicket = can('raise_ticket_page')
+  const canViewDataArchive = can('data_archive_view_page')
 
   const reportingGroupChildren: SidebarLinkItem[] = []
   if (canViewF4F5) {
@@ -105,6 +106,13 @@ export default function ErrPortalLayout({
       href: '/err-portal/project-management',
       label: t('err:project_management'),
       icon: <Cog className="h-5 w-5" />
+    })
+  }
+  if (canViewDataArchive) {
+    reportingGroupChildren.push({
+      href: '/err-portal/data-archive',
+      label: 'Data Archive',
+      icon: <Archive className="h-5 w-5" />
     })
   }
   if (canViewDashboard) {

--- a/src/app/err-portal/project-management/components/ProjectManagement.tsx
+++ b/src/app/err-portal/project-management/components/ProjectManagement.tsx
@@ -1025,9 +1025,12 @@ export default function ProjectManagement() {
                               </Button>
                             )}
                             {!r.is_historical && r.status === 'completed' && (
-                              <div className="flex items-center gap-0.5 text-xs text-muted-foreground shrink-0">
+                              <div
+                                className="flex items-center gap-0.5 text-xs text-muted-foreground shrink-0"
+                                title={r.completed_at ? `Completed on ${new Date(r.completed_at).toLocaleDateString()}` : 'No completion date recorded'}
+                              >
                                 <CheckCircle className="h-3 w-3 shrink-0" />
-                                <span>Done</span>
+                                <span>Done{r.completed_at ? ` ${new Date(r.completed_at).toLocaleDateString()}` : ''}</span>
                               </div>
                             )}
                           </div>

--- a/src/data/functions.json
+++ b/src/data/functions.json
@@ -47,5 +47,7 @@
   { "code": "raise_ticket_page", "module": "tickets", "label_ar": "فتح تذكرة (GitHub)", "label_en": "Raise a ticket", "description_en": "Use Raise a ticket to submit GitHub issues for the Mutual Aid Portal." },
   { "code": "compliance_view_page", "module": "compliance", "label_ar": "عرض صفحة الامتثال", "label_en": "View Compliance page", "description_en": "View the Visual Compliance (OFAC screening) page and queue." },
   { "code": "compliance_screen", "module": "compliance", "label_ar": "فحص أسماء المستفيدين", "label_en": "Screen payee names", "description_en": "Clear or flag F1 payee names in the compliance screening queue (visual OFAC check)." },
-  { "code": "compliance_finance_review", "module": "compliance", "label_ar": "مراجعة مالية للمشاريع الموسومة", "label_en": "Finance review flagged F1s", "description_en": "Approve or reject flagged F1s so they can (or cannot) proceed to the committed stage." }
+  { "code": "compliance_finance_review", "module": "compliance", "label_ar": "مراجعة مالية للمشاريع الموسومة", "label_en": "Finance review flagged F1s", "description_en": "Approve or reject flagged F1s so they can (or cannot) proceed to the committed stage." },
+  { "code": "data_archive_view_page", "module": "archive", "label_ar": "عرض صفحة أرشيف البيانات", "label_en": "View Data Archive page", "description_en": "View the Data Archive page listing completed projects and their original files." },
+  { "code": "data_archive_download", "module": "archive", "label_ar": "تنزيل أرشيف الملفات", "label_en": "Download data archive", "description_en": "Export a zip of original F1-F5 files (including payment confirmations) for completed projects." }
 ]

--- a/src/lib/dataArchive.ts
+++ b/src/lib/dataArchive.ts
@@ -1,0 +1,202 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+/** PostgREST `.in()` with hundreds of UUIDs can exceed URL limits and return empty data. */
+const IN_BATCH = 80
+
+function chunk<T>(items: T[]): T[][] {
+  const out: T[][] = []
+  for (let i = 0; i < items.length; i += IN_BATCH) {
+    out.push(items.slice(i, i + IN_BATCH))
+  }
+  return out
+}
+
+async function fetchIn(
+  supabase: SupabaseClient,
+  table: string,
+  select: string,
+  column: string,
+  ids: (string | number)[]
+): Promise<any[]> {
+  if (!ids.length) return []
+  const rows: any[] = []
+  for (const batch of chunk(ids)) {
+    const { data, error } = await supabase.from(table).select(select).in(column, batch)
+    if (error) throw error
+    rows.push(...(data || []))
+  }
+  return rows
+}
+
+export interface ArchiveProjectRow {
+  id: string
+  file_key: string | null
+  approval_file_key: string | null
+  mou_id: string | null
+}
+
+export interface ArchiveFile {
+  /** Form label used for grouping and manifest: F1 | F2 | F3 | F4 | F5 */
+  form: 'F1' | 'F2' | 'F3' | 'F4' | 'F5'
+  /** Target file name within the project's folder in the zip. */
+  name: string
+  /** Storage key in the `images` bucket, or null when the document is missing. */
+  storage_path: string | null
+}
+
+function ext(path: string): string {
+  const last = path.split('/').pop() || ''
+  const dot = last.lastIndexOf('.')
+  return dot > -1 ? last.slice(dot + 1).toLowerCase() : 'pdf'
+}
+
+/**
+ * Parse mous.payment_confirmation_file, which is either a plain storage key (legacy)
+ * or a JSON map of { [project_id]: { file_path, ... } }.
+ */
+export function paymentConfirmationPathForProject(
+  raw: string | null | undefined,
+  projectId: string
+): string | null {
+  if (!raw || typeof raw !== 'string') return null
+  try {
+    const parsed = JSON.parse(raw)
+    if (typeof parsed === 'string') return parsed.trim() || null
+    if (parsed && typeof parsed === 'object') {
+      const entry = (parsed as Record<string, { file_path?: unknown }>)[projectId]
+      return typeof entry?.file_path === 'string' ? entry.file_path.trim() || null : null
+    }
+  } catch {
+    // Legacy records store a single storage key rather than the per-project JSON map.
+    return raw.trim() || null
+  }
+  return null
+}
+
+/**
+ * Collect all original document references (F1-F5 + payment confirmation) for a set of
+ * completed projects. Missing documents are returned with storage_path = null so exports
+ * can record them in the manifest and the UI can show availability gaps.
+ */
+export async function collectArchiveFiles(
+  supabase: SupabaseClient,
+  projects: ArchiveProjectRow[]
+): Promise<Record<string, ArchiveFile[]>> {
+  const projectIds = projects.map((p) => p.id)
+
+  const mouIds = Array.from(new Set(projects.map((p) => p.mou_id).filter(Boolean))) as string[]
+  const mous = await fetchIn(
+    supabase,
+    'mous',
+    'id, file_key, signed_mou_file_key, payment_confirmation_file',
+    'id',
+    mouIds
+  )
+  const mouById = new Map<string, any>(mous.map((m: any) => [m.id, m]))
+
+  const summaries = await fetchIn(supabase, 'err_summary', 'id, project_id', 'project_id', projectIds)
+  const summaryIds = summaries.map((s: any) => s.id)
+  const summaryProjectById = new Map<number, string>(summaries.map((s: any) => [s.id, s.project_id]))
+  const f4Attachments = await fetchIn(
+    supabase,
+    'err_summary_attachments',
+    'summary_id, file_key, file_type',
+    'summary_id',
+    summaryIds
+  )
+
+  const reports = await fetchIn(supabase, 'err_program_report', 'id, project_id', 'project_id', projectIds)
+  const reportIds = reports.map((r: any) => r.id)
+  const reportProjectById = new Map<string, string>(reports.map((r: any) => [r.id, r.project_id]))
+  const f5Files = await fetchIn(
+    supabase,
+    'err_program_files',
+    'report_id, file_url, file_name',
+    'report_id',
+    reportIds
+  )
+
+  const f4ByProject = new Map<string, string[]>()
+  for (const a of f4Attachments) {
+    const pid = summaryProjectById.get(a.summary_id)
+    if (!pid || !a.file_key) continue
+    const list = f4ByProject.get(pid) || []
+    list.push(a.file_key)
+    f4ByProject.set(pid, list)
+  }
+
+  const f5ByProject = new Map<string, string[]>()
+  for (const f of f5Files) {
+    const pid = reportProjectById.get(f.report_id)
+    if (!pid || !f.file_url) continue
+    const list = f5ByProject.get(pid) || []
+    list.push(f.file_url)
+    f5ByProject.set(pid, list)
+  }
+
+  const out: Record<string, ArchiveFile[]> = {}
+  for (const p of projects) {
+    const files: ArchiveFile[] = []
+
+    files.push({
+      form: 'F1',
+      name: p.file_key ? `F1_workplan.${ext(p.file_key)}` : 'F1_workplan',
+      storage_path: p.file_key || null
+    })
+    files.push({
+      form: 'F2',
+      name: p.approval_file_key ? `F2_approval.${ext(p.approval_file_key)}` : 'F2_approval',
+      storage_path: p.approval_file_key || null
+    })
+
+    const mou = p.mou_id ? mouById.get(p.mou_id) : null
+    const mouGenerated: string | null = mou?.file_key || null
+    const mouSigned: string | null = mou?.signed_mou_file_key || null
+    const paymentPath = mou ? paymentConfirmationPathForProject(mou.payment_confirmation_file, p.id) : null
+    files.push({
+      form: 'F3',
+      name: mouGenerated ? `F3_MOU.${ext(mouGenerated)}` : 'F3_MOU',
+      storage_path: mouGenerated
+    })
+    files.push({
+      form: 'F3',
+      name: mouSigned ? `F3_MOU_signed.${ext(mouSigned)}` : 'F3_MOU_signed',
+      storage_path: mouSigned
+    })
+    files.push({
+      form: 'F3',
+      name: paymentPath ? `F3_payment_confirmation.${ext(paymentPath)}` : 'F3_payment_confirmation',
+      storage_path: paymentPath
+    })
+
+    const f4Paths = f4ByProject.get(p.id) || []
+    if (f4Paths.length === 0) {
+      files.push({ form: 'F4', name: 'F4_financial_report', storage_path: null })
+    } else {
+      f4Paths.forEach((path, i) => {
+        const suffix = f4Paths.length > 1 ? `_${i + 1}` : ''
+        files.push({ form: 'F4', name: `F4_financial_report${suffix}.${ext(path)}`, storage_path: path })
+      })
+    }
+
+    const f5Paths = f5ByProject.get(p.id) || []
+    if (f5Paths.length === 0) {
+      files.push({ form: 'F5', name: 'F5_program_report', storage_path: null })
+    } else {
+      f5Paths.forEach((path, i) => {
+        const suffix = f5Paths.length > 1 ? `_${i + 1}` : ''
+        files.push({ form: 'F5', name: `F5_program_report${suffix}.${ext(path)}`, storage_path: path })
+      })
+    }
+
+    out[p.id] = files
+  }
+  return out
+}
+
+/** Sanitize a string for use as a zip folder or file name. */
+export function safeName(value: string | null | undefined, fallback = 'Unknown'): string {
+  const s = (value || '').toString().trim()
+  if (!s) return fallback
+  return s.replace(/[\\/:*?"<>|]+/g, '-').replace(/\s+/g, ' ').trim()
+}


### PR DESCRIPTION
## Summary
- Adds a permission-gated **Data Archive** module in the ERR portal for exporting original F1–F5 files (including payment confirmations) for microgrants marked completed in a chosen period.
- Zip layout is `Month (YYYY-MM) > Backdonor Grant > Serial Number`, with a per-folder `_manifest.csv` for audit retention; missing files are listed as MISSING rather than failing the export.
- Records `completed_at` when a project is marked completed (SQL migration included) and surfaces that date in Project Management.

## Test plan
- [ ] Run `sql/add_completed_at_to_err_projects.sql` in Supabase
- [ ] Confirm users with `data_archive_view_page` / `data_archive_download` see Data Archive in the sidebar; others do not
- [ ] Complete a project in Project Management and verify `Done <date>` appears
- [ ] On Data Archive, filter by previous month and confirm completed projects load with file badges
- [ ] Export selected / export all and verify zip folder structure and `_manifest.csv`
- [ ] Toggle "Include undated" and confirm legacy completed projects with null `completed_at` appear
