### PR TITLE
Return missing-ID F1s to Ahmed after finance uploads ID

### DIFF
--- a/sql/add_compliance_id_uploaded_status.sql
+++ b/sql/add_compliance_id_uploaded_status.sql
@@ -1,0 +1,16 @@
+-- Allow finance_review_status = id_uploaded so missing-ID flags return to
+-- Ahmed's screening queue after finance attaches the document (instead of
+-- auto-approving into History).
+
+ALTER TABLE compliance_screenings
+  DROP CONSTRAINT IF EXISTS compliance_screenings_finance_review_status_check;
+
+ALTER TABLE compliance_screenings
+  ADD CONSTRAINT compliance_screenings_finance_review_status_check
+  CHECK (
+    finance_review_status IS NULL
+    OR finance_review_status IN ('pending', 'approved', 'rejected', 'id_uploaded')
+  );
+
+COMMENT ON COLUMN compliance_screenings.finance_review_status IS
+  'pending = awaiting finance; id_uploaded = ID attached, awaiting Ahmed re-clear; approved = resolved; rejected = flag dismissed as erroneous';

--- a/src/app/api/compliance/[id]/finance-review/route.ts
+++ b/src/app/api/compliance/[id]/finance-review/route.ts
@@ -64,18 +64,13 @@ export async function POST(
         )
       }
       if (screening.flag_type === 'missing_id') {
-        // ID must already be on the project (uploaded via upload-id)
-        const { data: project } = await supabase
-          .from('err_projects')
-          .select('identity_document_file_key')
-          .eq('id', screening.project_id)
-          .single()
-        if (!project?.identity_document_file_key) {
-          return NextResponse.json(
-            { error: 'Upload the missing ID document before approving this flag' },
-            { status: 400 }
-          )
-        }
+        return NextResponse.json(
+          {
+            error:
+              'Missing-ID flags are resolved by uploading the ID (returns to compliance for clearance), not by finance approve.'
+          },
+          { status: 400 }
+        )
       }
     }
 

--- a/src/app/api/compliance/[id]/upload-id/route.ts
+++ b/src/app/api/compliance/[id]/upload-id/route.ts
@@ -6,7 +6,10 @@ import { requirePermission } from '@/lib/requirePermission'
  * POST /api/compliance/[id]/upload-id
  * Finance uploads a missing ID document for a missing_id flag.
  * Body: { file_key: string } — storage path already uploaded to the images bucket.
- * Saves the key onto err_projects.identity_document_file_key and marks the flag approved.
+ *
+ * Saves the key onto err_projects.identity_document_file_key and returns the
+ * screening to Ahmed's compliance queue (finance_review_status = id_uploaded).
+ * Does NOT auto-approve into History — Ahmed must Clear after reviewing the ID.
  */
 export async function POST(
   request: Request,
@@ -44,11 +47,15 @@ export async function POST(
       .eq('id', screening.project_id)
     if (projectError) throw projectError
 
+    const trimmedNote = note ? String(note).trim() : ''
     const { error: screeningError } = await supabase
       .from('compliance_screenings')
       .update({
-        finance_review_status: 'approved',
-        finance_review_note: note || 'Identity document uploaded',
+        // Stay flagged/missing_id so commit remains blocked, but mark finance's
+        // step done so the row returns to Ahmed's screening queue for Clear.
+        finance_review_status: 'id_uploaded',
+        finance_review_note:
+          trimmedNote || 'Identity document uploaded — awaiting compliance clearance',
         finance_reviewed_by: perm.user.id,
         finance_reviewed_at: new Date().toISOString()
       })
@@ -57,7 +64,8 @@ export async function POST(
 
     return NextResponse.json({
       success: true,
-      identity_document_file_key: file_key
+      identity_document_file_key: file_key,
+      awaiting_compliance_clearance: true
     })
   } catch (error) {
     console.error('Error uploading identity document:', error)

--- a/src/app/api/compliance/queue/route.ts
+++ b/src/app/api/compliance/queue/route.ts
@@ -20,12 +20,17 @@ export async function GET(request: Request) {
     const countOnly = searchParams.get('count_only') === '1'
 
     if (countOnly) {
-      // Sidebar badge: pending screenings that still need Ahmed's attention —
-      // must have an F1 file, and must not already be past the commit gate.
+      // Sidebar badge: items that still need Ahmed's attention —
+      // pending screening OR missing-ID with ID uploaded awaiting his Clear.
+      // Must have an F1 file, and must not already be past the commit gate.
       const { data, error } = await supabase
         .from('compliance_screenings')
-        .select('id, err_projects!inner(file_key, temp_file_key, funding_status, status)')
-        .eq('status', 'pending_screening')
+        .select(
+          'id, status, flag_type, finance_review_status, err_projects!inner(file_key, temp_file_key, funding_status, status)'
+        )
+        .or(
+          'status.eq.pending_screening,and(status.eq.flagged,flag_type.eq.missing_id,finance_review_status.eq.id_uploaded)'
+        )
       if (error) throw error
       const count = (data || []).filter((r) => {
         const raw = (r as { err_projects?: unknown }).err_projects
@@ -159,16 +164,17 @@ export async function GET(request: Request) {
 
     // Visibility rules (Ahmed feedback):
     // 1) Always require an F1 document (file_key, with temp_file_key fallback).
-    //    Production previously only checked temp_file_key, so rows like
-    //    ERR-SK-64-155 appeared "without an F1" even though file_key existed.
-    // 2) Active work (pending screening / pending finance review) should not
-    //    include projects that already committed or are completed/declined —
-    //    those are past the compliance gate and clutter the queue.
+    // 2) Active work should not include projects that already committed or are
+    //    completed/declined. Active = pending screening, pending finance review,
+    //    or missing-ID with ID uploaded awaiting Ahmed's Clear.
     const visible = formatted.filter((r) => {
       if (!(r.f1_file_key || r.temp_file_key)) return false
       const isActiveWork =
         r.status === 'pending_screening' ||
-        (r.status === 'flagged' && r.finance_review_status === 'pending')
+        (r.status === 'flagged' && r.finance_review_status === 'pending') ||
+        (r.status === 'flagged' &&
+          r.flag_type === 'missing_id' &&
+          r.finance_review_status === 'id_uploaded')
       if (isActiveWork) {
         if (r.funding_status === 'committed') return false
         if (r.project_status === 'completed' || r.project_status === 'declined') return false

--- a/src/app/api/f2/uncommitted/route.ts
+++ b/src/app/api/f2/uncommitted/route.ts
@@ -100,7 +100,8 @@ export async function GET(request: Request) {
       if (!c || c.status !== 'flagged') return false
       if (c.finance_review_status === 'rejected') return false
       if (c.flag_type === 'sanctions_match') return true
-      if (c.flag_type === 'missing_id') return c.finance_review_status !== 'approved'
+      // Missing ID stays blocked until Ahmed clears (including after id_uploaded)
+      if (c.flag_type === 'missing_id') return true
       return c.finance_review_status !== 'approved'
     }
 

--- a/src/app/err-portal/compliance/page.tsx
+++ b/src/app/err-portal/compliance/page.tsx
@@ -24,7 +24,7 @@ interface Screening {
   flag_note: string | null
   alerted_at: string | null
   screened_at: string | null
-  finance_review_status: 'pending' | 'approved' | 'rejected' | null
+  finance_review_status: 'pending' | 'approved' | 'rejected' | 'id_uploaded' | null
   finance_review_note: string | null
   finance_reviewed_at: string | null
   created_at: string
@@ -65,6 +65,9 @@ function StatusBadge({ s }: { s: Screening }) {
     )
   }
   if (s.flag_type === 'missing_id') {
+    if (s.finance_review_status === 'id_uploaded') {
+      return <Badge variant="default" className="text-[10px] px-1.5 py-0 bg-amber-500">ID uploaded — awaiting clearance</Badge>
+    }
     if (s.finance_review_status === 'approved') {
       return <Badge variant="default" className="text-[10px] px-1.5 py-0 bg-green-600">Missing ID — document uploaded</Badge>
     }
@@ -377,7 +380,14 @@ export default function CompliancePage() {
   if (!canViewPage) return null
   if (isLoading) return <div className="text-center py-8">Loading...</div>
 
-  const pending = screenings.filter(s => s.status === 'pending_screening')
+  const awaitingIdClearance = (s: Screening) =>
+    s.status === 'flagged' &&
+    s.flag_type === 'missing_id' &&
+    s.finance_review_status === 'id_uploaded'
+
+  const pending = screenings.filter(
+    s => s.status === 'pending_screening' || awaitingIdClearance(s)
+  )
   const financeQueue = screenings.filter(
     s => s.status === 'flagged' && s.finance_review_status === 'pending'
   )
@@ -390,11 +400,14 @@ export default function CompliancePage() {
   const history = screenings.filter(
     s =>
       s.status !== 'pending_screening' &&
+      !awaitingIdClearance(s) &&
       !(s.status === 'flagged' && s.finance_review_status === 'pending')
   )
 
   const showScreeningActions =
-    canScreen && selected?.status === 'pending_screening'
+    canScreen &&
+    (selected?.status === 'pending_screening' ||
+      (selected != null && awaitingIdClearance(selected)))
   const showMissingIdFinance =
     canFinanceReview &&
     selected?.status === 'flagged' &&
@@ -442,8 +455,9 @@ export default function CompliancePage() {
         <CardHeader>
           <CardTitle>OFAC / Descartes Screening</CardTitle>
           <p className="text-sm text-muted-foreground">
-            Finance team screens payee names. Flag as <strong>Missing ID</strong> (finance uploads the document)
-            or <strong>Sanctions match</strong> (payment stopped — red alert). Clear when the name is fine.
+            Ahmed screens payee names. Flag as <strong>Missing ID</strong> (finance uploads the document,
+            then it returns here for Ahmed to Clear) or <strong>Sanctions match</strong> (payment stopped — red alert).
+            Clear when the name is fine.
           </p>
         </CardHeader>
         <CardContent>
@@ -499,6 +513,14 @@ export default function CompliancePage() {
                 <div className="rounded-md border-2 border-red-600 bg-red-50 px-3 py-2 text-sm text-red-950 font-medium">
                   PAYMENT MUST BE STOPPED — potential Descartes / sanctions list match.
                   Alert recipients: Finance team, Yara, Josh, Nihal, Santiago.
+                </div>
+              )}
+
+              {selected.flag_type === 'missing_id' &&
+                selected.finance_review_status === 'id_uploaded' && (
+                <div className="rounded-md border border-amber-500 bg-amber-50 px-3 py-2 text-sm text-amber-950">
+                  Finance uploaded an identity document. Review the ID against the payee name,
+                  then <strong>Clear</strong> to approve — or flag again if it still does not match.
                 </div>
               )}
 

--- a/src/lib/compliance.ts
+++ b/src/lib/compliance.ts
@@ -204,7 +204,8 @@ export async function sweepUnscreenedProjects(
  * Return the subset of project ids that are blocked from committing.
  *
  * - sanctions_match: blocked until finance dismisses the flag as erroneous
- * - missing_id: blocked until finance uploads an ID (approved) or dismisses the flag
+ * - missing_id: blocked until Ahmed clears after finance uploads the ID
+ *   (or dismisses the flag). ID upload alone does not unblock.
  * - legacy flagged rows with no flag_type: blocked until finance approves or dismisses
  */
 export async function getComplianceBlockedProjectIds(
@@ -231,8 +232,8 @@ export async function getComplianceBlockedProjectIds(
         continue
       }
       if (row.flag_type === 'missing_id') {
-        // Unblocked only after ID upload (approved)
-        if (review !== 'approved') blocked.push(row.project_id)
+        // Stay blocked through ID upload until Ahmed clears the screening
+        blocked.push(row.project_id)
         continue
       }
       // Legacy generic flag


### PR DESCRIPTION
## Summary
- After finance uploads a missing ID, the F1 no longer auto-approves into History.
- It returns to Ahmed's **Screening queue** with status **ID uploaded — awaiting clearance**.
- Ahmed must **Clear** (or re-flag) after reviewing the ID against the payee name.
- Commit remains blocked until Ahmed clears.

## Test plan
- [ ] Flag Missing ID → appears in Finance review
- [ ] Finance uploads ID → leaves Finance review, appears in Screening queue with amber badge
- [ ] Open uploaded ID works; Clear moves it to History and unblocks F2 commit
- [ ] Sanctions match flow unchanged
