### PR TITLE
Store login emails in compliance screened_by fields

### DIFF
--- a/sql/compliance_screened_by_login.sql
+++ b/sql/compliance_screened_by_login.sql
@@ -1,0 +1,55 @@
+-- Store login email (not users.id UUID) on compliance actor columns so the
+-- table is readable in Supabase / exports without joining auth.users.
+-- Backfills existing UUID values from public.users → auth.users.email.
+
+ALTER TABLE compliance_screenings
+  DROP CONSTRAINT IF EXISTS compliance_screenings_screened_by_fkey;
+
+ALTER TABLE compliance_screenings
+  DROP CONSTRAINT IF EXISTS compliance_screenings_finance_reviewed_by_fkey;
+
+ALTER TABLE compliance_screenings
+  ADD COLUMN IF NOT EXISTS screened_by_login TEXT;
+
+ALTER TABLE compliance_screenings
+  ADD COLUMN IF NOT EXISTS finance_reviewed_by_login TEXT;
+
+UPDATE compliance_screenings cs
+SET screened_by_login = au.email
+FROM users u
+JOIN auth.users au ON au.id = u.auth_user_id
+WHERE cs.screened_by IS NOT NULL
+  AND cs.screened_by::text = u.id::text
+  AND cs.screened_by_login IS NULL;
+
+UPDATE compliance_screenings cs
+SET finance_reviewed_by_login = au.email
+FROM users u
+JOIN auth.users au ON au.id = u.auth_user_id
+WHERE cs.finance_reviewed_by IS NOT NULL
+  AND cs.finance_reviewed_by::text = u.id::text
+  AND cs.finance_reviewed_by_login IS NULL;
+
+-- If a value was already an email (re-run safety), keep it.
+UPDATE compliance_screenings
+SET screened_by_login = screened_by::text
+WHERE screened_by_login IS NULL
+  AND screened_by IS NOT NULL
+  AND screened_by::text LIKE '%@%';
+
+UPDATE compliance_screenings
+SET finance_reviewed_by_login = finance_reviewed_by::text
+WHERE finance_reviewed_by_login IS NULL
+  AND finance_reviewed_by IS NOT NULL
+  AND finance_reviewed_by::text LIKE '%@%';
+
+ALTER TABLE compliance_screenings DROP COLUMN IF EXISTS screened_by;
+ALTER TABLE compliance_screenings DROP COLUMN IF EXISTS finance_reviewed_by;
+
+ALTER TABLE compliance_screenings RENAME COLUMN screened_by_login TO screened_by;
+ALTER TABLE compliance_screenings RENAME COLUMN finance_reviewed_by_login TO finance_reviewed_by;
+
+COMMENT ON COLUMN compliance_screenings.screened_by IS
+  'Login email of the compliance officer who cleared/flagged this F1';
+COMMENT ON COLUMN compliance_screenings.finance_reviewed_by IS
+  'Login email of the finance reviewer who dismissed/approved/uploaded ID';

--- a/sql/create_compliance_screenings.sql
+++ b/sql/create_compliance_screenings.sql
@@ -18,12 +18,12 @@ CREATE TABLE IF NOT EXISTS compliance_screenings (
   status TEXT NOT NULL DEFAULT 'pending_screening'
     CHECK (status IN ('pending_screening', 'cleared', 'flagged', 'auto_approved')),
   flag_note TEXT,
-  screened_by UUID REFERENCES users(id),
+  screened_by TEXT, -- login email of the compliance officer
   screened_at TIMESTAMPTZ,
   finance_review_status TEXT
     CHECK (finance_review_status IN ('pending', 'approved', 'rejected')),
   finance_review_note TEXT,
-  finance_reviewed_by UUID REFERENCES users(id),
+  finance_reviewed_by TEXT, -- login email of the finance reviewer
   finance_reviewed_at TIMESTAMPTZ,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/src/app/api/compliance/[id]/decision/route.ts
+++ b/src/app/api/compliance/[id]/decision/route.ts
@@ -15,6 +15,10 @@ export async function POST(
   try {
     const perm = await requirePermission('compliance_screen')
     if (perm instanceof NextResponse) return perm
+    const actorLogin = perm.user.email?.trim()
+    if (!actorLogin) {
+      return NextResponse.json({ error: 'Logged-in user has no email/login' }, { status: 400 })
+    }
 
     const supabase = getSupabaseRouteClient()
     const { action, note, flag_type } = await request.json()
@@ -55,7 +59,7 @@ export async function POST(
       status: action === 'clear' ? 'cleared' : 'flagged',
       flag_note: trimmedNote || null,
       flag_type: action === 'flag' ? flag_type : null,
-      screened_by: perm.user.id,
+      screened_by: actorLogin,
       screened_at: new Date().toISOString(),
       finance_review_status: action === 'flag' ? 'pending' : null,
       finance_review_note: null,

--- a/src/app/api/compliance/[id]/finance-review/route.ts
+++ b/src/app/api/compliance/[id]/finance-review/route.ts
@@ -20,6 +20,10 @@ export async function POST(
   try {
     const perm = await requirePermission('compliance_finance_review')
     if (perm instanceof NextResponse) return perm
+    const actorLogin = perm.user.email?.trim()
+    if (!actorLogin) {
+      return NextResponse.json({ error: 'Logged-in user has no email/login' }, { status: 400 })
+    }
 
     const supabase = getSupabaseRouteClient()
     const { action, note } = await request.json()
@@ -92,7 +96,7 @@ export async function POST(
           finance_review_note: note
             ? `Flag dismissed as erroneous: ${note}`
             : 'Flag dismissed as erroneous',
-          finance_reviewed_by: perm.user.id,
+          finance_reviewed_by: actorLogin,
           finance_reviewed_at: new Date().toISOString()
         })
         .eq('id', params.id)
@@ -106,7 +110,7 @@ export async function POST(
       .update({
         finance_review_status: 'approved',
         finance_review_note: note || null,
-        finance_reviewed_by: perm.user.id,
+        finance_reviewed_by: actorLogin,
         finance_reviewed_at: new Date().toISOString()
       })
       .eq('id', params.id)

--- a/src/app/api/compliance/[id]/upload-id/route.ts
+++ b/src/app/api/compliance/[id]/upload-id/route.ts
@@ -15,6 +15,10 @@ export async function POST(
   try {
     const perm = await requirePermission('compliance_finance_review')
     if (perm instanceof NextResponse) return perm
+    const actorLogin = perm.user.email?.trim()
+    if (!actorLogin) {
+      return NextResponse.json({ error: 'Logged-in user has no email/login' }, { status: 400 })
+    }
 
     const supabase = getSupabaseRouteClient()
     const { file_key, note } = await request.json()
@@ -49,7 +53,7 @@ export async function POST(
       .update({
         finance_review_status: 'approved',
         finance_review_note: note || 'Identity document uploaded',
-        finance_reviewed_by: perm.user.id,
+        finance_reviewed_by: actorLogin,
         finance_reviewed_at: new Date().toISOString()
       })
       .eq('id', params.id)

--- a/src/lib/requirePermission.ts
+++ b/src/lib/requirePermission.ts
@@ -5,7 +5,7 @@ import { getOverridesForUser } from '@/lib/userOverridesDb'
 
 export async function requirePermission(
   functionCode: string
-): Promise<{ user: { id: string; role: string } } | NextResponse> {
+): Promise<{ user: { id: string; role: string; email: string | null } } | NextResponse> {
   const supabase = getSupabaseRouteClient()
   const {
     data: { session },
@@ -38,5 +38,11 @@ export async function requirePermission(
       { status: 403 }
     )
   }
-  return { user: { id: userRow.id, role: userRow.role } }
+  return {
+    user: {
+      id: userRow.id,
+      role: userRow.role,
+      email: session.user.email ?? null
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- `screened_by` and `finance_reviewed_by` now store the actor’s login email instead of a users table UUID
- Existing live rows were backfilled (e.g. Ahmad → `aeraikat@proximity2humanity.org`)
- Clear / Flag / finance review / ID upload write the session email going forward

## Test plan
- [ ] In Supabase, confirm `compliance_screenings.screened_by` shows emails, not UUIDs
- [ ] Clear or flag an F1 and confirm the new row uses your login email
- [ ] Finance dismiss / upload-ID writes email into `finance_reviewed_by`
