### PR TITLE
Improve F4 expense grid UX: fill, formatting, and responsive layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-collapsible": "^1.1.3",
         "@radix-ui/react-dialog": "^1.1.13",
         "@radix-ui/react-label": "^2.1.7",
+        "@radix-ui/react-popover": "^1.1.20",
         "@radix-ui/react-select": "^2.1.6",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.3",
@@ -1896,6 +1897,417 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.20.tgz",
+      "integrity": "sha512-/PYqbsyuDkNj+IxMcRx71qNt6GelnuNulMwdCV7AtFEhUyK6XkbwreEN6CCLydMeTiDozBV4uv5aF5d12dDH7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.6",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-dismissable-layer": "1.1.16",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.13",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-popper": "1.3.4",
+        "@radix-ui/react-portal": "1.1.14",
+        "@radix-ui/react-presence": "1.1.8",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-slot": "1.3.0",
+        "@radix-ui/react-use-controllable-state": "1.2.4",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/primitive": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.6.tgz",
+      "integrity": "sha512-w9hl+724uYEgCGR3bhuRepjBtrNB/6gkhCnAf58Ke+SLbHPPQqVZZB59z60roB+5H+nh3nWTcdJhQdFMEydWmw==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.12.tgz",
+      "integrity": "sha512-ltXCE0glRomMZ9+u10d9o1Go+edqa1aLxufH59JRNNM3Yz1uvaeNWSaS1HeVh1X64agtdBG5JA1W1I6ySqWiwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-context": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.0.tgz",
+      "integrity": "sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.16.tgz",
+      "integrity": "sha512-t45h68IjFx0ccBnPJqk0X6ecv69LkCFWd6DNCFQX56mUnVEXZbNOLCH/u9fHlAjFZ1RrFdl8/m4zev7B7NyhXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.6",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-effect-event": "0.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+      "integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.13.tgz",
+      "integrity": "sha512-dE04aPEuP9rvKKT0d0KjSOtTEYNg6bmCYFsoSJpfC+y91Hic28ZfDCGgv6aJ+2Kw/LBXYipMZpyqVj/OD3Z8Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-popper": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.4.tgz",
+      "integrity": "sha512-PXnCa3XgTQk0FegMctxgqJXtFLZe4IFJdbUkB7jKSCKEpb6utEO4S9Vog/pkyCfEPdzM331gvE4xpztmBAfMng==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.12",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-use-rect": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2",
+        "@radix-ui/rect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.14.tgz",
+      "integrity": "sha512-REwjAGPMa3J9oyDE4cuWkZbwnCbbyky66NurquQklXMSDn67cl6oGFx2gO7KZhPtFNbNw9xTWNrti3VIhgluYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.8.tgz",
+      "integrity": "sha512-0hhyrQdXMaATgq4ammLG9+iPqsXxzZkgTSIxdrJHdfLnXO4Uo5L7BoO3/Xf0AEaettadGZWGGJMw6ujzQvIpGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+      "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.4.tgz",
+      "integrity": "sha512-cx2DixxmSfjCcEoRvDvy1NLd6SWK94XFcEEOZUcharUlXbmahFQGKCfwdKZL2ub34iIwOPOEFVF80xb+yfLYiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.6",
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.2.tgz",
+      "integrity": "sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.2.tgz",
+      "integrity": "sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/rect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.2.tgz",
+      "integrity": "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==",
+      "license": "MIT"
     },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.2.2",
@@ -8230,9 +8642,9 @@
       }
     },
     "node_modules/react-remove-scroll": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.3.tgz",
-      "integrity": "sha512-pnAi91oOk8g8ABQKGF5/M9qxmmOPxaAnopyTHYfqYEwJhyFrbbBtHuSgtKEoH0jpcxx5o3hXqH1mNd9/Oi+8iQ==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
       "license": "MIT",
       "dependencies": {
         "react-remove-scroll-bar": "^2.3.7",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-collapsible": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.13",
     "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-popover": "^1.1.20",
     "@radix-ui/react-select": "^2.1.6",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.3",

--- a/src/app/err-portal/f4-f5-reporting/components/F4ExpenseCellEditors.tsx
+++ b/src/app/err-portal/f4-f5-reporting/components/F4ExpenseCellEditors.tsx
@@ -1,0 +1,198 @@
+'use client'
+
+import { useEffect, useRef, useState, type CSSProperties } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { cn } from '@/lib/utils'
+import { formatAmountDisplay, parseAmountInput } from '@/lib/f4ExpenseUi'
+
+const selectableInputStyle: CSSProperties = {
+  userSelect: 'text',
+  WebkitUserSelect: 'text',
+}
+
+/** Count digit/decimal characters before caret (ignores commas/spaces). */
+function significantCharsBefore (value: string, caret: number): number {
+  let n = 0
+  const end = Math.min(caret, value.length)
+  for (let i = 0; i < end; i++) {
+    const ch = value[i]
+    if ((ch >= '0' && ch <= '9') || ch === '.' || ch === '-') n++
+  }
+  return n
+}
+
+function caretFromSignificant (formatted: string, significantCount: number): number {
+  if (significantCount <= 0) return 0
+  let seen = 0
+  for (let i = 0; i < formatted.length; i++) {
+    const ch = formatted[i]
+    if ((ch >= '0' && ch <= '9') || ch === '.' || ch === '-') {
+      seen++
+      if (seen >= significantCount) return i + 1
+    }
+  }
+  return formatted.length
+}
+
+/**
+ * Live-format amount string with thousand separators while typing.
+ * Preserves trailing "." so decimals can still be entered.
+ */
+export function formatAmountWhileTyping (raw: string, locale: string): string {
+  const cleaned = String(raw || '')
+    .replace(/[\u0660-\u0669]/g, (d) => String(d.charCodeAt(0) - 0x0660))
+    .replace(/[^\d.-]/g, '')
+
+  if (!cleaned) return ''
+  if (cleaned === '-' || cleaned === '.' || cleaned === '-.') return cleaned
+
+  const neg = cleaned.startsWith('-')
+  const body = neg ? cleaned.slice(1) : cleaned
+  const endsWithDot = body.endsWith('.')
+  const parts = body.split('.')
+  const intRaw = parts[0] || '0'
+  const fracRaw = parts.length > 1 ? parts.slice(1).join('').replace(/\D/g, '') : null
+
+  const intNum = Number(intRaw.replace(/^0+(?=\d)/, '') || '0')
+  if (!Number.isFinite(intNum)) return cleaned
+
+  const intFormatted = intNum.toLocaleString(locale.startsWith('ar') ? 'en-US' : 'en-US', {
+    maximumFractionDigits: 0,
+  })
+
+  let out = (neg ? '-' : '') + intFormatted
+  if (fracRaw != null) {
+    out += '.' + fracRaw.slice(0, 2)
+  } else if (endsWithDot) {
+    out += '.'
+  }
+  return out
+}
+
+/** Compact field that expands on focus for description / seller / receipt reference. */
+export function F4ExpandableTextInput ({
+  value,
+  onChange,
+  placeholder,
+  disabled,
+  multiline = true,
+}: {
+  value: string
+  onChange: (next: string) => void
+  placeholder?: string
+  disabled?: boolean
+  multiline?: boolean
+}) {
+  const [focused, setFocused] = useState(false)
+
+  if (multiline) {
+    return (
+      <div className={cn('relative w-full', focused && 'z-20')}>
+        <Textarea
+          disabled={disabled}
+          placeholder={placeholder}
+          value={value}
+          rows={focused ? 4 : 1}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+          onChange={(e) => onChange(e.target.value)}
+          className={cn(
+            'w-full resize-none text-sm transition-[min-height,box-shadow] duration-150',
+            'select-text selection:bg-blue-200 selection:text-blue-900 dark:selection:bg-blue-800 dark:selection:text-blue-100',
+            focused
+              ? 'min-h-[6rem] shadow-md ring-2 ring-ring'
+              : 'min-h-8 h-8 overflow-hidden py-1.5 leading-5'
+          )}
+          style={selectableInputStyle}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <Input
+      disabled={disabled}
+      placeholder={placeholder}
+      value={value}
+      onFocus={() => setFocused(true)}
+      onBlur={() => setFocused(false)}
+      onChange={(e) => onChange(e.target.value)}
+      className={cn(
+        'h-8 select-text transition-shadow',
+        focused && 'ring-2 ring-ring shadow-sm'
+      )}
+      style={selectableInputStyle}
+    />
+  )
+}
+
+/** Amount input with live thousand separators while typing. */
+export function F4FormattedAmountInput ({
+  value,
+  onChange,
+  placeholder,
+  className,
+  disabled,
+}: {
+  value: number | null | undefined
+  onChange: (next: number | null) => void
+  placeholder?: string
+  className?: string
+  disabled?: boolean
+}) {
+  const { i18n } = useTranslation()
+  const locale = i18n.language || 'en'
+  const [focused, setFocused] = useState(false)
+  const [text, setText] = useState(() => formatAmountDisplay(value, locale))
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    if (!focused) {
+      setText(formatAmountDisplay(value, locale))
+    }
+  }, [value, locale, focused])
+
+  return (
+    <Input
+      ref={inputRef}
+      disabled={disabled}
+      className={cn(
+        'h-8 select-text text-right tabular-nums selection:bg-blue-200 selection:text-blue-900 dark:selection:bg-blue-800 dark:selection:text-blue-100',
+        className
+      )}
+      style={selectableInputStyle}
+      inputMode="decimal"
+      placeholder={placeholder}
+      value={focused ? text : formatAmountDisplay(value, locale)}
+      onFocus={() => {
+        setFocused(true)
+        setText(formatAmountDisplay(value, locale))
+      }}
+      onBlur={() => {
+        setFocused(false)
+        const parsed = parseAmountInput(text)
+        onChange(parsed)
+        setText(formatAmountDisplay(parsed, locale))
+      }}
+      onChange={(e) => {
+        const el = e.target
+        const raw = el.value
+        const sigBefore = significantCharsBefore(raw, el.selectionStart ?? raw.length)
+        const formatted = formatAmountWhileTyping(raw, locale)
+        setText(formatted)
+        const parsed = parseAmountInput(formatted)
+        if (parsed != null || formatted.trim() === '' || formatted === '-' || formatted.endsWith('.')) {
+          onChange(formatted.trim() === '' || formatted === '-' ? null : parsed)
+        }
+        requestAnimationFrame(() => {
+          const node = inputRef.current
+          if (!node) return
+          const pos = caretFromSignificant(formatted, sigBefore)
+          node.setSelectionRange(pos, pos)
+        })
+      }}
+    />
+  )
+}

--- a/src/app/err-portal/f4-f5-reporting/components/F4ExpenseSectorSelect.tsx
+++ b/src/app/err-portal/f4-f5-reporting/components/F4ExpenseSectorSelect.tsx
@@ -1,7 +1,10 @@
 'use client'
 
+import { useTranslation } from 'react-i18next'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { cn } from '@/lib/utils'
 import type { F4SectorRow } from '@/lib/f4ExpenseSectors'
+import { sectorPillClassName } from '@/lib/f4ExpenseUi'
 
 interface F4ExpenseSectorSelectProps {
   sectors: F4SectorRow[]
@@ -12,6 +15,15 @@ interface F4ExpenseSectorSelectProps {
   disabled?: boolean
 }
 
+function sectorLabel (s: F4SectorRow, lang: string): string {
+  const en = (s.sector_name_en || '').trim()
+  if (lang.startsWith('ar')) {
+    const ar = (s.sector_name_ar || '').trim()
+    return ar || en
+  }
+  return en
+}
+
 export function F4ExpenseSectorSelect ({
   sectors,
   valueEn,
@@ -20,8 +32,11 @@ export function F4ExpenseSectorSelect ({
   className,
   disabled,
 }: F4ExpenseSectorSelectProps) {
+  const { i18n } = useTranslation()
+  const lang = i18n.language || 'en'
   const trimmed = (valueEn || '').trim()
   const selected = sectors.find((s) => s.sector_name_en.trim() === trimmed)
+
   return (
     <Select
       disabled={disabled || sectors.length === 0}
@@ -31,17 +46,61 @@ export function F4ExpenseSectorSelect ({
         onChangeEn(s ? s.sector_name_en.trim() : '')
       }}
     >
-      <SelectTrigger className={className ?? 'h-8 w-full'}>
-        <SelectValue placeholder={sectors.length === 0 ? '…' : placeholder} />
+      <SelectTrigger className={cn('h-8 w-full min-w-0', className)}>
+        {selected ? (
+          <span
+            className={cn(
+              'inline-flex max-w-full truncate rounded-full border px-2 py-0.5 text-xs font-medium',
+              sectorPillClassName(selected.sector_name_en)
+            )}
+          >
+            {sectorLabel(selected, lang)}
+          </span>
+        ) : (
+          <SelectValue placeholder={sectors.length === 0 ? '…' : placeholder} />
+        )}
       </SelectTrigger>
       <SelectContent>
         {sectors.map((s) => (
-          <SelectItem key={s.id} value={s.id}>
-            {s.sector_name_en.trim()}
-            {s.sector_name_ar ? ` (${s.sector_name_ar})` : ''}
+          <SelectItem key={s.id} value={s.id} className="py-1.5">
+            <span
+              className={cn(
+                'inline-flex max-w-full rounded-full border px-2.5 py-0.5 text-xs font-medium',
+                sectorPillClassName(s.sector_name_en)
+              )}
+            >
+              {sectorLabel(s, lang)}
+            </span>
           </SelectItem>
         ))}
       </SelectContent>
     </Select>
+  )
+}
+
+/** Read-only colored sector pill (uses stored English name + locale label lookup). */
+export function F4SectorPill ({
+  valueEn,
+  sectors,
+}: {
+  valueEn: string | null | undefined
+  sectors: F4SectorRow[]
+}) {
+  const { i18n } = useTranslation()
+  const lang = i18n.language || 'en'
+  const trimmed = (valueEn || '').trim()
+  if (!trimmed) return <span className="text-muted-foreground">-</span>
+  const row = sectors.find((s) => s.sector_name_en.trim() === trimmed)
+  const label = row ? sectorLabel(row, lang) : trimmed
+  return (
+    <span
+      className={cn(
+        'inline-flex max-w-full truncate rounded-full border px-2.5 py-0.5 text-xs font-medium',
+        sectorPillClassName(trimmed)
+      )}
+      title={label}
+    >
+      {label}
+    </span>
   )
 }

--- a/src/app/err-portal/f4-f5-reporting/components/F4ExpensesEditableTable.tsx
+++ b/src/app/err-portal/f4-f5-reporting/components/F4ExpensesEditableTable.tsx
@@ -1,0 +1,373 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { cn } from '@/lib/utils'
+import type { F4SectorRow } from '@/lib/f4ExpenseSectors'
+import {
+  applyExpenseFill,
+  formatAmountDisplay,
+  type F4ExpenseFillKey,
+} from '@/lib/f4ExpenseUi'
+import { F4ExpandableTextInput, F4FormattedAmountInput } from './F4ExpenseCellEditors'
+import { F4ExpenseSectorSelect, F4SectorPill } from './F4ExpenseSectorSelect'
+import { F4PaymentMethodPill, F4PaymentMethodSelect } from './F4PaymentMethodSelect'
+
+export type F4ExpenseRow = {
+  expense_id?: string | number
+  expense_activity?: string | null
+  expense_description?: string | null
+  expense_amount_sdg?: number | null
+  expense_amount?: number | null
+  payment_date?: string | null
+  payment_method?: string | null
+  receipt_no?: string | null
+  seller?: string | null
+  is_draft?: boolean
+  [key: string]: unknown
+}
+
+type FillState = { key: F4ExpenseFillKey; fromRow: number; hoverRow: number } | null
+
+function FillHandle ({
+  active,
+  onPointerDown,
+}: {
+  active?: boolean
+  onPointerDown: (e: React.PointerEvent) => void
+}) {
+  return (
+    <span
+      role="presentation"
+      onPointerDown={onPointerDown}
+      className={cn(
+        'absolute bottom-0 right-0 z-10 h-2.5 w-2.5 translate-x-1/4 translate-y-1/4 cursor-crosshair rounded-[1px] border border-background bg-primary',
+        'opacity-0 group-hover/fill:opacity-100',
+        active && 'opacity-100 ring-2 ring-primary/40'
+      )}
+      title="Drag to fill"
+    />
+  )
+}
+
+function FillableWrap ({
+  children,
+  fillKey,
+  rowIndex,
+  fill,
+  onFillStart,
+  className,
+}: {
+  children: React.ReactNode
+  fillKey: F4ExpenseFillKey
+  rowIndex: number
+  fill: FillState
+  onFillStart: (key: F4ExpenseFillKey, row: number, e: React.PointerEvent) => void
+  className?: string
+}) {
+  const inRange =
+    fill &&
+    fill.key === fillKey &&
+    rowIndex >= Math.min(fill.fromRow, fill.hoverRow) &&
+    rowIndex <= Math.max(fill.fromRow, fill.hoverRow)
+
+  return (
+    <div
+      className={cn(
+        'group/fill relative min-h-8',
+        inRange && 'rounded-sm bg-primary/10 ring-1 ring-primary/30',
+        className
+      )}
+      data-fill-row={rowIndex}
+      data-fill-key={fillKey}
+      onPointerEnter={() => {
+        /* hover row updated via document listener */
+      }}
+    >
+      {children}
+      <FillHandle
+        active={fill?.key === fillKey && fill.fromRow === rowIndex}
+        onPointerDown={(e) => onFillStart(fillKey, rowIndex, e)}
+      />
+    </div>
+  )
+}
+
+interface F4ExpensesEditableTableProps {
+  expenses: F4ExpenseRow[]
+  onChange: (next: F4ExpenseRow[]) => void
+  sectors: F4SectorRow[]
+  fxRate: number | null
+  editable?: boolean
+  emptyLabel?: string
+}
+
+export function F4ExpensesEditableTable ({
+  expenses,
+  onChange,
+  sectors,
+  fxRate,
+  editable = true,
+  emptyLabel,
+}: F4ExpensesEditableTableProps) {
+  const { t, i18n } = useTranslation(['f4f5'])
+  const locale = i18n.language || 'en'
+  const [fill, setFill] = useState<FillState>(null)
+  const fillRef = useRef<FillState>(null)
+  const expensesRef = useRef(expenses)
+  const fxRef = useRef(fxRate)
+  const onChangeRef = useRef(onChange)
+
+  useEffect(() => {
+    fillRef.current = fill
+  }, [fill])
+  useEffect(() => {
+    expensesRef.current = expenses
+  }, [expenses])
+  useEffect(() => {
+    fxRef.current = fxRate
+  }, [fxRate])
+  useEffect(() => {
+    onChangeRef.current = onChange
+  }, [onChange])
+
+  const patchRow = useCallback(
+    (idx: number, patch: Partial<F4ExpenseRow>) => {
+      const arr = [...expensesRef.current]
+      arr[idx] = { ...arr[idx], ...patch }
+      onChangeRef.current(arr)
+    },
+    []
+  )
+
+  const onFillStart = useCallback((key: F4ExpenseFillKey, row: number, e: React.PointerEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    ;(e.target as HTMLElement).setPointerCapture?.(e.pointerId)
+    setFill({ key, fromRow: row, hoverRow: row })
+  }, [])
+
+  useEffect(() => {
+    if (!fill) return
+
+    const onMove = (e: PointerEvent) => {
+      const el = document.elementFromPoint(e.clientX, e.clientY) as HTMLElement | null
+      const cell = el?.closest?.('[data-fill-row][data-fill-key]') as HTMLElement | null
+      if (!cell) return
+      const key = cell.getAttribute('data-fill-key') as F4ExpenseFillKey | null
+      const row = Number(cell.getAttribute('data-fill-row'))
+      const cur = fillRef.current
+      if (!cur || !key || key !== cur.key || !Number.isFinite(row)) return
+      if (row !== cur.hoverRow) {
+        setFill({ ...cur, hoverRow: row })
+      }
+    }
+
+    const onUp = () => {
+      const cur = fillRef.current
+      setFill(null)
+      if (!cur) return
+      if (cur.fromRow === cur.hoverRow) return
+      onChangeRef.current(
+        applyExpenseFill(expensesRef.current, cur.key, cur.fromRow, cur.hoverRow, fxRef.current) as F4ExpenseRow[]
+      )
+    }
+
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
+    window.addEventListener('pointercancel', onUp)
+    return () => {
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+      window.removeEventListener('pointercancel', onUp)
+    }
+  }, [fill])
+
+  return (
+    <div className="border rounded overflow-x-auto select-text">
+      {expenses.length === 0 ? (
+        <div className="p-3 text-sm text-muted-foreground">
+          {emptyLabel || (t('f4.preview.expenses.empty') as string)}
+        </div>
+      ) : (
+        <Table className="select-text">
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[14%] py-1 px-2 text-xs">{t('f4.preview.expenses.cols.activity')}</TableHead>
+              <TableHead className="w-[18%] py-1 px-2 text-xs">{t('f4.preview.expenses.cols.description')}</TableHead>
+              <TableHead className="w-[10%] py-1 px-2 text-right text-xs">Amount (SDG)</TableHead>
+              <TableHead className="w-[10%] py-1 px-2 text-right text-xs">Amount (USD)</TableHead>
+              <TableHead className="w-[12%] py-1 px-2 text-xs">{t('f4.preview.expenses.cols.payment_date')}</TableHead>
+              <TableHead className="w-[10%] py-1 px-2 text-xs">{t('f4.preview.expenses.cols.method')}</TableHead>
+              <TableHead className="w-[10%] py-1 px-2 text-xs">{t('f4.preview.expenses.cols.receipt_no')}</TableHead>
+              <TableHead className="w-[12%] py-1 px-2 text-xs">{t('f4.preview.expenses.cols.seller')}</TableHead>
+              {editable ? (
+                <TableHead className="w-[8%] py-1 px-2 text-xs text-right">
+                  {t('f4.preview.expenses.cols.actions')}
+                </TableHead>
+              ) : null}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {expenses.map((ex, idx) => (
+              <TableRow key={(ex.expense_id as string) || idx} className="text-sm">
+                <TableCell className="py-1 px-2 align-top">
+                  {editable ? (
+                    <FillableWrap fillKey="expense_activity" rowIndex={idx} fill={fill} onFillStart={onFillStart}>
+                      <F4ExpenseSectorSelect
+                        sectors={sectors}
+                        valueEn={ex.expense_activity || ''}
+                        onChangeEn={(sectorNameEn) => patchRow(idx, { expense_activity: sectorNameEn })}
+                        placeholder={t('f4.preview.expenses.sector_placeholder') as string}
+                        className="h-8 w-full"
+                      />
+                    </FillableWrap>
+                  ) : (
+                    <F4SectorPill valueEn={ex.expense_activity} sectors={sectors} />
+                  )}
+                </TableCell>
+
+                <TableCell className="py-1 px-2 align-top">
+                  {editable ? (
+                    <F4ExpandableTextInput
+                      value={ex.expense_description || ''}
+                      onChange={(v) => patchRow(idx, { expense_description: v })}
+                      placeholder={t('f4.preview.expenses.cols.description') as string}
+                    />
+                  ) : (
+                    <span className="block max-w-[14rem] whitespace-pre-wrap break-words text-sm">
+                      {ex.expense_description || '-'}
+                    </span>
+                  )}
+                </TableCell>
+
+                <TableCell className="py-1 px-2 text-right align-top">
+                  {editable ? (
+                    <FillableWrap fillKey="expense_amount_sdg" rowIndex={idx} fill={fill} onFillStart={onFillStart}>
+                      <F4FormattedAmountInput
+                        value={ex.expense_amount_sdg}
+                        placeholder="SDG"
+                        onChange={(enteredValue) => {
+                          const sdg = enteredValue
+                          patchRow(idx, {
+                            expense_amount_sdg: sdg,
+                            expense_amount:
+                              fxRate && fxRate > 0 && sdg != null && sdg > 0
+                                ? +(sdg / fxRate).toFixed(2)
+                                : ex.expense_amount,
+                          })
+                        }}
+                      />
+                    </FillableWrap>
+                  ) : (
+                    formatAmountDisplay(ex.expense_amount_sdg, locale) || '-'
+                  )}
+                </TableCell>
+
+                <TableCell className="py-1 px-2 text-right align-top">
+                  {editable ? (
+                    <FillableWrap fillKey="expense_amount" rowIndex={idx} fill={fill} onFillStart={onFillStart}>
+                      <F4FormattedAmountInput
+                        value={ex.expense_amount}
+                        placeholder="USD"
+                        onChange={(enteredValue) => {
+                          const usd = enteredValue
+                          patchRow(idx, {
+                            expense_amount: usd,
+                            expense_amount_sdg:
+                              fxRate && fxRate > 0 && usd != null && usd > 0
+                                ? +(usd * fxRate).toFixed(2)
+                                : ex.expense_amount_sdg,
+                          })
+                        }}
+                      />
+                    </FillableWrap>
+                  ) : (
+                    formatAmountDisplay(ex.expense_amount, locale) || '-'
+                  )}
+                </TableCell>
+
+                <TableCell className="py-1 px-2 align-top">
+                  {editable ? (
+                    <FillableWrap fillKey="payment_date" rowIndex={idx} fill={fill} onFillStart={onFillStart}>
+                      <Input
+                        className="h-8"
+                        type="date"
+                        value={ex.payment_date || ''}
+                        onChange={(e) => patchRow(idx, { payment_date: e.target.value })}
+                      />
+                    </FillableWrap>
+                  ) : (
+                    ex.payment_date ? new Date(ex.payment_date).toLocaleDateString() : '-'
+                  )}
+                </TableCell>
+
+                <TableCell className="py-1 px-2 align-top">
+                  {editable ? (
+                    <FillableWrap fillKey="payment_method" rowIndex={idx} fill={fill} onFillStart={onFillStart}>
+                      <F4PaymentMethodSelect
+                        value={ex.payment_method || 'Bank Transfer'}
+                        onChange={(v) => patchRow(idx, { payment_method: v })}
+                        placeholder={t('f4.preview.expenses.cols.method') as string}
+                      />
+                    </FillableWrap>
+                  ) : (
+                    <F4PaymentMethodPill value={ex.payment_method} />
+                  )}
+                </TableCell>
+
+                <TableCell className="py-1 px-2 align-top">
+                  {editable ? (
+                    <FillableWrap fillKey="receipt_no" rowIndex={idx} fill={fill} onFillStart={onFillStart}>
+                      <Input
+                        className="h-8"
+                        placeholder={t('f4.preview.expenses.cols.receipt_no') as string}
+                        value={ex.receipt_no || ''}
+                        onChange={(e) => patchRow(idx, { receipt_no: e.target.value })}
+                      />
+                    </FillableWrap>
+                  ) : (
+                    ex.receipt_no || '-'
+                  )}
+                </TableCell>
+
+                <TableCell className="py-1 px-2 align-top">
+                  {editable ? (
+                    <F4ExpandableTextInput
+                      value={ex.seller || ''}
+                      onChange={(v) => patchRow(idx, { seller: v })}
+                      placeholder={t('f4.preview.expenses.cols.seller') as string}
+                    />
+                  ) : (
+                    <span className="block max-w-[10rem] whitespace-pre-wrap break-words text-sm">
+                      {ex.seller || '-'}
+                    </span>
+                  )}
+                </TableCell>
+
+                {editable ? (
+                  <TableCell className="py-1 px-2 text-right align-top">
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => {
+                        const arr = [...expenses]
+                        arr.splice(idx, 1)
+                        onChange(arr)
+                      }}
+                    >
+                      {t('f4.preview.expenses.cols.delete')}
+                    </Button>
+                  </TableCell>
+                ) : null}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  )
+}

--- a/src/app/err-portal/f4-f5-reporting/components/F4ExpensesEditableTable.tsx
+++ b/src/app/err-portal/f4-f5-reporting/components/F4ExpensesEditableTable.tsx
@@ -32,6 +32,28 @@ export type F4ExpenseRow = {
 
 type FillState = { key: F4ExpenseFillKey; fromRow: number; hoverRow: number } | null
 
+const STICKY_FIRST_COL =
+  'sticky left-0 z-20 bg-background shadow-[2px_0_5px_-2px_rgba(0,0,0,0.12)]'
+
+/**
+ * Detect fine pointer + hover (mouse/trackpad), independent of viewport width.
+ * Narrow split-screen panels on a laptop still report fine pointer.
+ */
+function useFinePointerInput (): boolean {
+  const [finePointer, setFinePointer] = useState(true)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return
+    const mq = window.matchMedia('(hover: hover) and (pointer: fine)')
+    const sync = () => setFinePointer(mq.matches)
+    sync()
+    mq.addEventListener('change', sync)
+    return () => mq.removeEventListener('change', sync)
+  }, [])
+
+  return finePointer
+}
+
 function FillHandle ({
   active,
   onPointerDown,
@@ -57,15 +79,25 @@ function FillableWrap ({
   children,
   fillKey,
   rowIndex,
+  rowCount,
   fill,
   onFillStart,
+  onFillDown,
+  fillDownLabel,
+  showPointerFill,
+  showTouchFillDown,
   className,
 }: {
   children: React.ReactNode
   fillKey: F4ExpenseFillKey
   rowIndex: number
+  rowCount: number
   fill: FillState
   onFillStart: (key: F4ExpenseFillKey, row: number, e: React.PointerEvent) => void
+  onFillDown: (key: F4ExpenseFillKey, fromRow: number) => void
+  fillDownLabel: string
+  showPointerFill: boolean
+  showTouchFillDown: boolean
   className?: string
 }) {
   const inRange =
@@ -73,25 +105,42 @@ function FillableWrap ({
     fill.key === fillKey &&
     rowIndex >= Math.min(fill.fromRow, fill.hoverRow) &&
     rowIndex <= Math.max(fill.fromRow, fill.hoverRow)
+  const canFillDown = showTouchFillDown && rowIndex < rowCount - 1
 
   return (
     <div
       className={cn(
-        'group/fill relative min-h-8',
+        'relative min-h-8',
+        showPointerFill && 'group/fill',
         inRange && 'rounded-sm bg-primary/10 ring-1 ring-primary/30',
         className
       )}
       data-fill-row={rowIndex}
       data-fill-key={fillKey}
-      onPointerEnter={() => {
-        /* hover row updated via document listener */
-      }}
     >
       {children}
-      <FillHandle
-        active={fill?.key === fillKey && fill.fromRow === rowIndex}
-        onPointerDown={(e) => onFillStart(fillKey, rowIndex, e)}
-      />
+      {showPointerFill ? (
+        <FillHandle
+          active={fill?.key === fillKey && fill.fromRow === rowIndex}
+          onPointerDown={(e) => onFillStart(fillKey, rowIndex, e)}
+        />
+      ) : null}
+      {canFillDown ? (
+        <button
+          type="button"
+          className={cn(
+            'mt-1 w-full rounded border border-dashed border-muted-foreground/40 px-1 py-0.5',
+            'text-[10px] font-medium text-muted-foreground active:bg-muted'
+          )}
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            onFillDown(fillKey, rowIndex)
+          }}
+        >
+          {fillDownLabel}
+        </button>
+      ) : null}
     </div>
   )
 }
@@ -115,6 +164,8 @@ export function F4ExpensesEditableTable ({
 }: F4ExpensesEditableTableProps) {
   const { t, i18n } = useTranslation(['f4f5'])
   const locale = i18n.language || 'en'
+  const fillDownLabel = t('f4.preview.expenses.fill_down', { defaultValue: 'Fill Down' }) as string
+  const finePointer = useFinePointerInput()
   const [fill, setFill] = useState<FillState>(null)
   const fillRef = useRef<FillState>(null)
   const expensesRef = useRef(expenses)
@@ -134,20 +185,33 @@ export function F4ExpensesEditableTable ({
     onChangeRef.current = onChange
   }, [onChange])
 
-  const patchRow = useCallback(
-    (idx: number, patch: Partial<F4ExpenseRow>) => {
-      const arr = [...expensesRef.current]
-      arr[idx] = { ...arr[idx], ...patch }
-      onChangeRef.current(arr)
-    },
-    []
-  )
+  const patchRow = useCallback((idx: number, patch: Partial<F4ExpenseRow>) => {
+    const arr = [...expensesRef.current]
+    arr[idx] = { ...arr[idx], ...patch }
+    onChangeRef.current(arr)
+  }, [])
+
+  const removeRow = useCallback((idx: number) => {
+    const arr = [...expensesRef.current]
+    arr.splice(idx, 1)
+    onChangeRef.current(arr)
+  }, [])
 
   const onFillStart = useCallback((key: F4ExpenseFillKey, row: number, e: React.PointerEvent) => {
     e.preventDefault()
     e.stopPropagation()
     ;(e.target as HTMLElement).setPointerCapture?.(e.pointerId)
     setFill({ key, fromRow: row, hoverRow: row })
+  }, [])
+
+  /** Touch Fill Down: reuse applyExpenseFill from this row through the last row. */
+  const onFillDown = useCallback((key: F4ExpenseFillKey, fromRow: number) => {
+    const rows = expensesRef.current
+    const toRow = rows.length - 1
+    if (toRow <= fromRow) return
+    onChangeRef.current(
+      applyExpenseFill(rows, key, fromRow, toRow, fxRef.current) as F4ExpenseRow[]
+    )
   }, [])
 
   useEffect(() => {
@@ -186,188 +250,212 @@ export function F4ExpensesEditableTable ({
     }
   }, [fill])
 
+  if (expenses.length === 0) {
+    return (
+      <div className="border rounded p-3 text-sm text-muted-foreground select-text">
+        {emptyLabel || (t('f4.preview.expenses.empty') as string)}
+      </div>
+    )
+  }
+
+  const rowCount = expenses.length
+
+  const fillWrapProps = (fillKey: F4ExpenseFillKey, rowIndex: number) => ({
+    fillKey,
+    rowIndex,
+    rowCount,
+    fill,
+    onFillStart,
+    onFillDown,
+    fillDownLabel,
+    showPointerFill: finePointer,
+    showTouchFillDown: !finePointer,
+  })
+
   return (
-    <div className="border rounded overflow-x-auto select-text">
-      {expenses.length === 0 ? (
-        <div className="p-3 text-sm text-muted-foreground">
-          {emptyLabel || (t('f4.preview.expenses.empty') as string)}
-        </div>
-      ) : (
-        <Table className="select-text">
-          <TableHeader>
-            <TableRow>
-              <TableHead className="w-[14%] py-1 px-2 text-xs">{t('f4.preview.expenses.cols.activity')}</TableHead>
-              <TableHead className="w-[18%] py-1 px-2 text-xs">{t('f4.preview.expenses.cols.description')}</TableHead>
-              <TableHead className="w-[10%] py-1 px-2 text-right text-xs">Amount (SDG)</TableHead>
-              <TableHead className="w-[10%] py-1 px-2 text-right text-xs">Amount (USD)</TableHead>
-              <TableHead className="w-[12%] py-1 px-2 text-xs">{t('f4.preview.expenses.cols.payment_date')}</TableHead>
-              <TableHead className="w-[10%] py-1 px-2 text-xs">{t('f4.preview.expenses.cols.method')}</TableHead>
-              <TableHead className="w-[10%] py-1 px-2 text-xs">{t('f4.preview.expenses.cols.receipt_no')}</TableHead>
-              <TableHead className="w-[12%] py-1 px-2 text-xs">{t('f4.preview.expenses.cols.seller')}</TableHead>
+    <div className="w-full max-w-full min-w-0 border rounded overflow-x-auto select-text overscroll-x-contain">
+      <Table className="select-text min-w-[1100px] w-max">
+        <TableHeader>
+          <TableRow>
+            <TableHead
+              className={cn(
+                'min-w-[140px] py-1 px-2 text-xs',
+                STICKY_FIRST_COL,
+                'z-30 bg-muted/95'
+              )}
+            >
+              {t('f4.preview.expenses.cols.activity')}
+            </TableHead>
+            <TableHead className="min-w-[180px] py-1 px-2 text-xs">
+              {t('f4.preview.expenses.cols.description')}
+            </TableHead>
+            <TableHead className="min-w-[110px] py-1 px-2 text-right text-xs">Amount (SDG)</TableHead>
+            <TableHead className="min-w-[110px] py-1 px-2 text-right text-xs">Amount (USD)</TableHead>
+            <TableHead className="min-w-[130px] py-1 px-2 text-xs">
+              {t('f4.preview.expenses.cols.payment_date')}
+            </TableHead>
+            <TableHead className="min-w-[120px] py-1 px-2 text-xs">
+              {t('f4.preview.expenses.cols.method')}
+            </TableHead>
+            <TableHead className="min-w-[110px] py-1 px-2 text-xs">
+              {t('f4.preview.expenses.cols.receipt_no')}
+            </TableHead>
+            <TableHead className="min-w-[140px] py-1 px-2 text-xs">
+              {t('f4.preview.expenses.cols.seller')}
+            </TableHead>
+            {editable ? (
+              <TableHead className="min-w-[80px] py-1 px-2 text-xs text-right">
+                {t('f4.preview.expenses.cols.actions')}
+              </TableHead>
+            ) : null}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {expenses.map((ex, idx) => (
+            <TableRow key={(ex.expense_id as string) || idx} className="text-sm">
+              <TableCell className={cn('py-1 px-2 align-top', STICKY_FIRST_COL)}>
+                {editable ? (
+                  <FillableWrap {...fillWrapProps('expense_activity', idx)}>
+                    <F4ExpenseSectorSelect
+                      sectors={sectors}
+                      valueEn={ex.expense_activity || ''}
+                      onChangeEn={(sectorNameEn) => patchRow(idx, { expense_activity: sectorNameEn })}
+                      placeholder={t('f4.preview.expenses.sector_placeholder') as string}
+                      className="h-8 w-full"
+                    />
+                  </FillableWrap>
+                ) : (
+                  <F4SectorPill valueEn={ex.expense_activity} sectors={sectors} />
+                )}
+              </TableCell>
+
+              <TableCell className="py-1 px-2 align-top">
+                {editable ? (
+                  <F4ExpandableTextInput
+                    value={ex.expense_description || ''}
+                    onChange={(v) => patchRow(idx, { expense_description: v })}
+                    placeholder={t('f4.preview.expenses.cols.description') as string}
+                  />
+                ) : (
+                  <span className="block max-w-[14rem] whitespace-pre-wrap break-words text-sm">
+                    {ex.expense_description || '-'}
+                  </span>
+                )}
+              </TableCell>
+
+              <TableCell className="py-1 px-2 text-right align-top">
+                {editable ? (
+                  <FillableWrap {...fillWrapProps('expense_amount_sdg', idx)}>
+                    <F4FormattedAmountInput
+                      value={ex.expense_amount_sdg}
+                      placeholder="SDG"
+                      onChange={(sdg) => {
+                        patchRow(idx, {
+                          expense_amount_sdg: sdg,
+                          expense_amount:
+                            fxRate && fxRate > 0 && sdg != null && sdg > 0
+                              ? +(sdg / fxRate).toFixed(2)
+                              : ex.expense_amount,
+                        })
+                      }}
+                    />
+                  </FillableWrap>
+                ) : (
+                  formatAmountDisplay(ex.expense_amount_sdg, locale) || '-'
+                )}
+              </TableCell>
+
+              <TableCell className="py-1 px-2 text-right align-top">
+                {editable ? (
+                  <FillableWrap {...fillWrapProps('expense_amount', idx)}>
+                    <F4FormattedAmountInput
+                      value={ex.expense_amount}
+                      placeholder="USD"
+                      onChange={(usd) => {
+                        patchRow(idx, {
+                          expense_amount: usd,
+                          expense_amount_sdg:
+                            fxRate && fxRate > 0 && usd != null && usd > 0
+                              ? +(usd * fxRate).toFixed(2)
+                              : ex.expense_amount_sdg,
+                        })
+                      }}
+                    />
+                  </FillableWrap>
+                ) : (
+                  formatAmountDisplay(ex.expense_amount, locale) || '-'
+                )}
+              </TableCell>
+
+              <TableCell className="py-1 px-2 align-top">
+                {editable ? (
+                  <FillableWrap {...fillWrapProps('payment_date', idx)}>
+                    <Input
+                      className="h-8"
+                      type="date"
+                      value={ex.payment_date || ''}
+                      onChange={(e) => patchRow(idx, { payment_date: e.target.value })}
+                    />
+                  </FillableWrap>
+                ) : (
+                  ex.payment_date ? new Date(ex.payment_date).toLocaleDateString() : '-'
+                )}
+              </TableCell>
+
+              <TableCell className="py-1 px-2 align-top">
+                {editable ? (
+                  <FillableWrap {...fillWrapProps('payment_method', idx)}>
+                    <F4PaymentMethodSelect
+                      value={ex.payment_method || 'Bank Transfer'}
+                      onChange={(v) => patchRow(idx, { payment_method: v })}
+                      placeholder={t('f4.preview.expenses.cols.method') as string}
+                    />
+                  </FillableWrap>
+                ) : (
+                  <F4PaymentMethodPill value={ex.payment_method} />
+                )}
+              </TableCell>
+
+              <TableCell className="py-1 px-2 align-top">
+                {editable ? (
+                  <FillableWrap {...fillWrapProps('receipt_no', idx)}>
+                    <Input
+                      className="h-8"
+                      placeholder={t('f4.preview.expenses.cols.receipt_no') as string}
+                      value={ex.receipt_no || ''}
+                      onChange={(e) => patchRow(idx, { receipt_no: e.target.value })}
+                    />
+                  </FillableWrap>
+                ) : (
+                  ex.receipt_no || '-'
+                )}
+              </TableCell>
+
+              <TableCell className="py-1 px-2 align-top">
+                {editable ? (
+                  <F4ExpandableTextInput
+                    value={ex.seller || ''}
+                    onChange={(v) => patchRow(idx, { seller: v })}
+                    placeholder={t('f4.preview.expenses.cols.seller') as string}
+                  />
+                ) : (
+                  <span className="block max-w-[10rem] whitespace-pre-wrap break-words text-sm">
+                    {ex.seller || '-'}
+                  </span>
+                )}
+              </TableCell>
+
               {editable ? (
-                <TableHead className="w-[8%] py-1 px-2 text-xs text-right">
-                  {t('f4.preview.expenses.cols.actions')}
-                </TableHead>
+                <TableCell className="py-1 px-2 text-right align-top">
+                  <Button variant="destructive" size="sm" onClick={() => removeRow(idx)}>
+                    {t('f4.preview.expenses.cols.delete')}
+                  </Button>
+                </TableCell>
               ) : null}
             </TableRow>
-          </TableHeader>
-          <TableBody>
-            {expenses.map((ex, idx) => (
-              <TableRow key={(ex.expense_id as string) || idx} className="text-sm">
-                <TableCell className="py-1 px-2 align-top">
-                  {editable ? (
-                    <FillableWrap fillKey="expense_activity" rowIndex={idx} fill={fill} onFillStart={onFillStart}>
-                      <F4ExpenseSectorSelect
-                        sectors={sectors}
-                        valueEn={ex.expense_activity || ''}
-                        onChangeEn={(sectorNameEn) => patchRow(idx, { expense_activity: sectorNameEn })}
-                        placeholder={t('f4.preview.expenses.sector_placeholder') as string}
-                        className="h-8 w-full"
-                      />
-                    </FillableWrap>
-                  ) : (
-                    <F4SectorPill valueEn={ex.expense_activity} sectors={sectors} />
-                  )}
-                </TableCell>
-
-                <TableCell className="py-1 px-2 align-top">
-                  {editable ? (
-                    <F4ExpandableTextInput
-                      value={ex.expense_description || ''}
-                      onChange={(v) => patchRow(idx, { expense_description: v })}
-                      placeholder={t('f4.preview.expenses.cols.description') as string}
-                    />
-                  ) : (
-                    <span className="block max-w-[14rem] whitespace-pre-wrap break-words text-sm">
-                      {ex.expense_description || '-'}
-                    </span>
-                  )}
-                </TableCell>
-
-                <TableCell className="py-1 px-2 text-right align-top">
-                  {editable ? (
-                    <FillableWrap fillKey="expense_amount_sdg" rowIndex={idx} fill={fill} onFillStart={onFillStart}>
-                      <F4FormattedAmountInput
-                        value={ex.expense_amount_sdg}
-                        placeholder="SDG"
-                        onChange={(enteredValue) => {
-                          const sdg = enteredValue
-                          patchRow(idx, {
-                            expense_amount_sdg: sdg,
-                            expense_amount:
-                              fxRate && fxRate > 0 && sdg != null && sdg > 0
-                                ? +(sdg / fxRate).toFixed(2)
-                                : ex.expense_amount,
-                          })
-                        }}
-                      />
-                    </FillableWrap>
-                  ) : (
-                    formatAmountDisplay(ex.expense_amount_sdg, locale) || '-'
-                  )}
-                </TableCell>
-
-                <TableCell className="py-1 px-2 text-right align-top">
-                  {editable ? (
-                    <FillableWrap fillKey="expense_amount" rowIndex={idx} fill={fill} onFillStart={onFillStart}>
-                      <F4FormattedAmountInput
-                        value={ex.expense_amount}
-                        placeholder="USD"
-                        onChange={(enteredValue) => {
-                          const usd = enteredValue
-                          patchRow(idx, {
-                            expense_amount: usd,
-                            expense_amount_sdg:
-                              fxRate && fxRate > 0 && usd != null && usd > 0
-                                ? +(usd * fxRate).toFixed(2)
-                                : ex.expense_amount_sdg,
-                          })
-                        }}
-                      />
-                    </FillableWrap>
-                  ) : (
-                    formatAmountDisplay(ex.expense_amount, locale) || '-'
-                  )}
-                </TableCell>
-
-                <TableCell className="py-1 px-2 align-top">
-                  {editable ? (
-                    <FillableWrap fillKey="payment_date" rowIndex={idx} fill={fill} onFillStart={onFillStart}>
-                      <Input
-                        className="h-8"
-                        type="date"
-                        value={ex.payment_date || ''}
-                        onChange={(e) => patchRow(idx, { payment_date: e.target.value })}
-                      />
-                    </FillableWrap>
-                  ) : (
-                    ex.payment_date ? new Date(ex.payment_date).toLocaleDateString() : '-'
-                  )}
-                </TableCell>
-
-                <TableCell className="py-1 px-2 align-top">
-                  {editable ? (
-                    <FillableWrap fillKey="payment_method" rowIndex={idx} fill={fill} onFillStart={onFillStart}>
-                      <F4PaymentMethodSelect
-                        value={ex.payment_method || 'Bank Transfer'}
-                        onChange={(v) => patchRow(idx, { payment_method: v })}
-                        placeholder={t('f4.preview.expenses.cols.method') as string}
-                      />
-                    </FillableWrap>
-                  ) : (
-                    <F4PaymentMethodPill value={ex.payment_method} />
-                  )}
-                </TableCell>
-
-                <TableCell className="py-1 px-2 align-top">
-                  {editable ? (
-                    <FillableWrap fillKey="receipt_no" rowIndex={idx} fill={fill} onFillStart={onFillStart}>
-                      <Input
-                        className="h-8"
-                        placeholder={t('f4.preview.expenses.cols.receipt_no') as string}
-                        value={ex.receipt_no || ''}
-                        onChange={(e) => patchRow(idx, { receipt_no: e.target.value })}
-                      />
-                    </FillableWrap>
-                  ) : (
-                    ex.receipt_no || '-'
-                  )}
-                </TableCell>
-
-                <TableCell className="py-1 px-2 align-top">
-                  {editable ? (
-                    <F4ExpandableTextInput
-                      value={ex.seller || ''}
-                      onChange={(v) => patchRow(idx, { seller: v })}
-                      placeholder={t('f4.preview.expenses.cols.seller') as string}
-                    />
-                  ) : (
-                    <span className="block max-w-[10rem] whitespace-pre-wrap break-words text-sm">
-                      {ex.seller || '-'}
-                    </span>
-                  )}
-                </TableCell>
-
-                {editable ? (
-                  <TableCell className="py-1 px-2 text-right align-top">
-                    <Button
-                      variant="destructive"
-                      size="sm"
-                      onClick={() => {
-                        const arr = [...expenses]
-                        arr.splice(idx, 1)
-                        onChange(arr)
-                      }}
-                    >
-                      {t('f4.preview.expenses.cols.delete')}
-                    </Button>
-                  </TableCell>
-                ) : null}
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      )}
+          ))}
+        </TableBody>
+      </Table>
     </div>
   )
 }

--- a/src/app/err-portal/f4-f5-reporting/components/F4PaymentMethodSelect.tsx
+++ b/src/app/err-portal/f4-f5-reporting/components/F4PaymentMethodSelect.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { cn } from '@/lib/utils'
+import {
+  PAYMENT_METHOD_OPTIONS,
+  paymentMethodPillClassName,
+} from '@/lib/f4ExpenseUi'
+
+interface F4PaymentMethodSelectProps {
+  value: string
+  onChange: (method: string) => void
+  placeholder?: string
+  className?: string
+  disabled?: boolean
+}
+
+export function F4PaymentMethodSelect ({
+  value,
+  onChange,
+  placeholder = 'Method',
+  className,
+  disabled,
+}: F4PaymentMethodSelectProps) {
+  const current = (value || 'Bank Transfer').trim() || 'Bank Transfer'
+
+  return (
+    <Select disabled={disabled} value={current} onValueChange={onChange}>
+      <SelectTrigger className={cn('h-8 w-full min-w-0', className)}>
+        <span
+          className={cn(
+            'inline-flex max-w-full truncate rounded-full border px-2 py-0.5 text-xs font-medium',
+            paymentMethodPillClassName(current)
+          )}
+        >
+          {current}
+        </span>
+      </SelectTrigger>
+      <SelectContent>
+        {PAYMENT_METHOD_OPTIONS.map((m) => (
+          <SelectItem key={m} value={m} className="py-1.5">
+            <span
+              className={cn(
+                'inline-flex rounded-full border px-2.5 py-0.5 text-xs font-medium',
+                paymentMethodPillClassName(m)
+              )}
+            >
+              {m}
+            </span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+export function F4PaymentMethodPill ({ value }: { value: string | null | undefined }) {
+  const v = (value || '').trim()
+  if (!v) return <span className="text-muted-foreground">-</span>
+  return (
+    <span
+      className={cn(
+        'inline-flex max-w-full truncate rounded-full border px-2.5 py-0.5 text-xs font-medium',
+        paymentMethodPillClassName(v)
+      )}
+    >
+      {v}
+    </span>
+  )
+}

--- a/src/app/err-portal/f4-f5-reporting/components/UploadF4Modal.tsx
+++ b/src/app/err-portal/f4-f5-reporting/components/UploadF4Modal.tsx
@@ -25,7 +25,8 @@ import {
   normalizeReportDateInput,
 } from '@/lib/reportUploadDate'
 import { type F4SectorRow } from '@/lib/f4ExpenseSectors'
-import { F4ExpenseSectorSelect } from './F4ExpenseSectorSelect'
+import { F4ExpensesEditableTable } from './F4ExpensesEditableTable'
+import { F4ExpandableTextInput, F4FormattedAmountInput } from './F4ExpenseCellEditors'
 import { WizardFullscreenShell, WIZARD_FULLSCREEN_DIALOG_CLASS } from './WizardFullscreenShell'
 
 interface UploadF4ModalProps {
@@ -1210,209 +1211,13 @@ export default function UploadF4Modal({ open, onOpenChange, onSaved, initialProj
                   } as any]))}
                 >{t('f4.preview.expenses.add')}</Button>
               </div>
-              <div className="border rounded overflow-hidden select-text">
-                {expensesDraft.length === 0 ? (
-                  <div className="p-3 text-sm text-muted-foreground">{t('f4.preview.expenses.empty')}</div>
-                ) : (
-                  <Table className="select-text">
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead className="w-[14%] py-1 px-2 text-xs">{t('f4.preview.expenses.cols.activity')}</TableHead>
-                        <TableHead className="w-[20%] py-1 px-2 text-xs">{t('f4.preview.expenses.cols.description')}</TableHead>
-                        <TableHead className="w-[10%] py-1 px-2 text-right text-xs">Amount (SDG)</TableHead>
-                        <TableHead className="w-[10%] py-1 px-2 text-right text-xs">Amount (USD)</TableHead>
-                        <TableHead className="w-[12%] py-1 px-2 text-xs">{t('f4.preview.expenses.cols.payment_date')}</TableHead>
-                        <TableHead className="w-[10%] py-1 px-2 text-xs">{t('f4.preview.expenses.cols.method')}</TableHead>
-                        <TableHead className="w-[10%] py-1 px-2 text-xs">{t('f4.preview.expenses.cols.receipt_no')}</TableHead>
-                        <TableHead className="w-[14%] py-1 px-2 text-xs">{t('f4.preview.expenses.cols.seller')}</TableHead>
-                        <TableHead className="w-[8%] py-1 px-2 text-xs text-right">{t('f4.preview.expenses.cols.actions')}</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {expensesDraft.map((ex, idx) => (
-                        <TableRow key={idx} className="text-sm">
-                          <TableCell className="py-1 px-2" style={{ userSelect: 'text' }}>
-                            <F4ExpenseSectorSelect
-                              sectors={f4Sectors}
-                              valueEn={ex.expense_activity || ''}
-                              onChangeEn={(sectorNameEn) => {
-                                const arr = [...expensesDraft]
-                                arr[idx] = { ...arr[idx], expense_activity: sectorNameEn }
-                                setExpensesDraft(arr)
-                              }}
-                              placeholder={t('f4.preview.expenses.sector_placeholder') as string}
-                              className="h-8 w-full"
-                            />
-                          </TableCell>
-                          <TableCell className="py-1 px-2" style={{ userSelect: 'text' }}>
-                            <Input 
-                              className="h-8 select-text selection:bg-blue-200 selection:text-blue-900 dark:selection:bg-blue-800 dark:selection:text-blue-100" 
-                              style={selectableInputStyle}
-                              placeholder={t('f4.preview.expenses.cols.description') as string} 
-                              value={ex.expense_description || ''} 
-                              onMouseDown={(e) => {
-                                // Removed logging(`Expense ${idx} Description onMouseDown`, e.target as HTMLInputElement, e)
-                              }}
-                              onSelect={(e) => {
-                                // Removed logging(`Expense ${idx} Description onSelect`, e.target as HTMLInputElement, e)
-                              }}
-                              onFocus={(e) => {
-                                // Removed logging(`Expense ${idx} Description onFocus`, e.target as HTMLInputElement, e)
-                              }}
-                              onChange={(e)=>{
-                                const arr=[...expensesDraft]; arr[idx]={...arr[idx], expense_description: e.target.value}; setExpensesDraft(arr)
-                              }} 
-                            />
-                          </TableCell>
-                          <TableCell className="py-1 px-2 text-right" style={{ userSelect: 'text' }}>
-                            <Input 
-                              className="h-8 select-text selection:bg-blue-200 selection:text-blue-900 dark:selection:bg-blue-800 dark:selection:text-blue-100" 
-                              style={selectableInputStyle}
-                              type="number" 
-                              placeholder="SDG" 
-                              value={ex.expense_amount_sdg != null ? String(ex.expense_amount_sdg) : ''} 
-                              onMouseDown={(e) => {
-                                // Removed logging(`Expense ${idx} SDG Amount onMouseDown`, e.target as HTMLInputElement, e)
-                              }}
-                              onSelect={(e) => {
-                                // Removed logging(`Expense ${idx} SDG Amount onSelect`, e.target as HTMLInputElement, e)
-                              }}
-                              onFocus={(e) => {
-                                // Removed logging(`Expense ${idx} SDG Amount onFocus`, e.target as HTMLInputElement, e)
-                              }}
-                              onChange={(e)=>{
-                                const enteredValue = parseFloat(e.target.value) || 0
-                                const arr = [...expensesDraft]
-                                arr[idx] = {
-                                  ...arr[idx],
-                                  expense_amount_sdg: enteredValue || null,
-                                  // Auto-calculate USD if exchange rate is set
-                                  expense_amount: (fxRate && fxRate > 0 && enteredValue > 0) ? +(enteredValue / fxRate).toFixed(2) : arr[idx].expense_amount
-                                }
-                                setExpensesDraft(arr)
-                              }} 
-                            />
-                          </TableCell>
-                          <TableCell className="py-1 px-2 text-right" style={{ userSelect: 'text' }}>
-                            <Input 
-                              className="h-8 select-text selection:bg-blue-200 selection:text-blue-900 dark:selection:bg-blue-800 dark:selection:text-blue-100" 
-                              style={selectableInputStyle}
-                              type="number" 
-                              placeholder="USD" 
-                              value={ex.expense_amount != null ? String(ex.expense_amount) : ''} 
-                              onMouseDown={(e) => {
-                                // Removed logging(`Expense ${idx} USD Amount onMouseDown`, e.target as HTMLInputElement, e)
-                              }}
-                              onSelect={(e) => {
-                                // Removed logging(`Expense ${idx} USD Amount onSelect`, e.target as HTMLInputElement, e)
-                              }}
-                              onFocus={(e) => {
-                                // Removed logging(`Expense ${idx} USD Amount onFocus`, e.target as HTMLInputElement, e)
-                              }}
-                              onChange={(e)=>{
-                                const enteredValue = parseFloat(e.target.value) || 0
-                                const arr = [...expensesDraft]
-                                arr[idx] = {
-                                  ...arr[idx],
-                                  expense_amount: enteredValue || null,
-                                  // Auto-calculate SDG if exchange rate is set
-                                  expense_amount_sdg: (fxRate && fxRate > 0 && enteredValue > 0) ? +(enteredValue * fxRate).toFixed(2) : arr[idx].expense_amount_sdg
-                                }
-                                setExpensesDraft(arr)
-                              }} 
-                            />
-                          </TableCell>
-                          <TableCell className="py-1 px-2" style={{ userSelect: 'text' }}>
-                            <Input 
-                              className="h-8 select-text selection:bg-blue-200 selection:text-blue-900 dark:selection:bg-blue-800 dark:selection:text-blue-100" 
-                              style={selectableInputStyle}
-                              type="date" 
-                              placeholder={t('f4.preview.expenses.cols.payment_date') as string} 
-                              value={ex.payment_date || ''} 
-                              onMouseDown={(e) => {
-                                // Removed logging(`Expense ${idx} Payment Date onMouseDown`, e.target as HTMLInputElement, e)
-                              }}
-                              onSelect={(e) => {
-                                // Removed logging(`Expense ${idx} Payment Date onSelect`, e.target as HTMLInputElement, e)
-                              }}
-                              onFocus={(e) => {
-                                // Removed logging(`Expense ${idx} Payment Date onFocus`, e.target as HTMLInputElement, e)
-                              }}
-                              onChange={(e)=>{
-                                const arr=[...expensesDraft]; arr[idx]={...arr[idx], payment_date: e.target.value}; setExpensesDraft(arr)
-                              }} 
-                            />
-                          </TableCell>
-                          <TableCell className="py-1 px-2">
-                            <Select value={ex.payment_method || 'Bank Transfer'} onValueChange={(v)=>{
-                              const arr=[...expensesDraft]; arr[idx]={...arr[idx], payment_method: v}; setExpensesDraft(arr)
-                            }}>
-                              <SelectTrigger className="h-8 w-full">
-                                <SelectValue placeholder={t('f4.preview.expenses.cols.method') as string} />
-                              </SelectTrigger>
-                              <SelectContent>
-                                <SelectItem value="Bank Transfer">Bank Transfer</SelectItem>
-                                <SelectItem value="Cash">Cash</SelectItem>
-                              </SelectContent>
-                            </Select>
-                          </TableCell>
-                          <TableCell className="py-1 px-2" style={{ userSelect: 'text' }}>
-                            <Input 
-                              className="h-8 select-text selection:bg-blue-200 selection:text-blue-900 dark:selection:bg-blue-800 dark:selection:text-blue-100" 
-                              style={selectableInputStyle}
-                              placeholder={t('f4.preview.expenses.cols.receipt_no') as string} 
-                              value={ex.receipt_no || ''} 
-                              onMouseDown={(e) => {
-                                // Removed logging(`Expense ${idx} Receipt No onMouseDown`, e.target as HTMLInputElement, e)
-                              }}
-                              onSelect={(e) => {
-                                // Removed logging(`Expense ${idx} Receipt No onSelect`, e.target as HTMLInputElement, e)
-                              }}
-                              onFocus={(e) => {
-                                // Removed logging(`Expense ${idx} Receipt No onFocus`, e.target as HTMLInputElement, e)
-                              }}
-                              onChange={(e)=>{
-                                const arr=[...expensesDraft]; arr[idx]={...arr[idx], receipt_no: e.target.value}; setExpensesDraft(arr)
-                              }} 
-                            />
-                          </TableCell>
-                          <TableCell className="py-1 px-2" style={{ userSelect: 'text' }}>
-                            <Input 
-                              className="h-8 select-text selection:bg-blue-200 selection:text-blue-900 dark:selection:bg-blue-800 dark:selection:text-blue-100" 
-                              style={selectableInputStyle}
-                              placeholder={t('f4.preview.expenses.cols.seller') as string} 
-                              value={ex.seller || ''} 
-                              onMouseDown={(e) => {
-                                // Removed logging(`Expense ${idx} Seller onMouseDown`, e.target as HTMLInputElement, e)
-                              }}
-                              onSelect={(e) => {
-                                // Removed logging(`Expense ${idx} Seller onSelect`, e.target as HTMLInputElement, e)
-                              }}
-                              onFocus={(e) => {
-                                // Removed logging(`Expense ${idx} Seller onFocus`, e.target as HTMLInputElement, e)
-                              }}
-                              onChange={(e)=>{
-                                const arr=[...expensesDraft]; arr[idx]={...arr[idx], seller: e.target.value}; setExpensesDraft(arr)
-                              }} 
-                            />
-                          </TableCell>
-                          <TableCell className="py-1 px-2 text-right">
-                            <Button
-                              variant="destructive"
-                              size="sm"
-                              onClick={() => {
-                                const arr = [...expensesDraft]
-                                arr.splice(idx, 1)
-                                setExpensesDraft(arr)
-                              }}
-                            >{t('f4.preview.expenses.cols.delete')}</Button>
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                )}
-              </div>
+              <F4ExpensesEditableTable
+                expenses={expensesDraft}
+                onChange={setExpensesDraft}
+                sectors={f4Sectors}
+                fxRate={fxRate}
+                editable
+              />
             </div>
 
             {/* Financials */}
@@ -1533,11 +1338,11 @@ export default function UploadF4Modal({ open, onOpenChange, onSaved, initialProj
                               receiptRows.map((row: any, idx: number) => (
                                 <TableRow key={`receipt-row-${idx}`}>
                                   <TableCell>
-                                    <Input
+                                    <F4ExpandableTextInput
                                       value={row?.reference || ''}
-                                      onChange={(e) => {
+                                      onChange={(v) => {
                                         const nextRows = [...receiptRows]
-                                        nextRows[idx] = { ...nextRows[idx], reference: e.target.value }
+                                        nextRows[idx] = { ...nextRows[idx], reference: v }
                                         setSummaryDraft((s: any) => ({
                                           ...(s || {}),
                                           receipt_check: { ...(s?.receipt_check || {}), receipts: nextRows, confirmed: false },
@@ -1547,13 +1352,11 @@ export default function UploadF4Modal({ open, onOpenChange, onSaved, initialProj
                                     />
                                   </TableCell>
                                   <TableCell>
-                                    <Input
-                                      type="number"
-                                      value={row?.amount_sdg != null ? String(row.amount_sdg) : ''}
-                                      onChange={(e) => {
+                                    <F4FormattedAmountInput
+                                      value={row?.amount_sdg != null ? Number(row.amount_sdg) : null}
+                                      onChange={(num) => {
                                         const nextRows = [...receiptRows]
-                                        const num = parseFloat(e.target.value)
-                                        nextRows[idx] = { ...nextRows[idx], amount_sdg: Number.isFinite(num) ? num : null }
+                                        nextRows[idx] = { ...nextRows[idx], amount_sdg: num }
                                         setSummaryDraft((s: any) => ({
                                           ...(s || {}),
                                           receipt_check: { ...(s?.receipt_check || {}), receipts: nextRows, confirmed: false },

--- a/src/app/err-portal/f4-f5-reporting/components/UploadF4Modal.tsx
+++ b/src/app/err-portal/f4-f5-reporting/components/UploadF4Modal.tsx
@@ -10,7 +10,6 @@ import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { supabase } from '@/lib/supabaseClient'
-import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { CollapsibleRow } from '@/components/ui/collapsible'
 import type { RegionSelection, WizardKind, WizardPageEntry } from '../f4Wizard/types'
@@ -1066,17 +1065,17 @@ export default function UploadF4Modal({ open, onOpenChange, onSaved, initialProj
               }
             />
           ) : step === 'preview' ? (
-          <div className="space-y-6 select-text">
+          <div className="space-y-6 select-text min-w-0 max-w-full">
             {/* Form Content */}
-            <div className="space-y-6">
+            <div className="space-y-6 min-w-0 max-w-full">
             {/* Summary Header */}
-            <div className="space-y-3">
-              <div className="grid grid-cols-2 gap-4">
-                <div>
+            <div className="space-y-3 min-w-0">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 min-w-0">
+                <div className="min-w-0">
                   <Label>{t('f4.preview.labels.err_room')}</Label>
-                  <div className="h-10 flex items-center px-3 rounded border bg-muted/50">{projectMeta?.roomLabel || '-'}</div>
+                  <div className="h-10 flex items-center px-3 rounded border bg-muted/50 truncate">{projectMeta?.roomLabel || '-'}</div>
                 </div>
-              <div>
+              <div className="min-w-0">
                 <Label>{t('f4.preview.labels.report_date')} *</Label>
                 <Input
                   className="select-text"
@@ -1154,8 +1153,8 @@ export default function UploadF4Modal({ open, onOpenChange, onSaved, initialProj
                 />
               </div>
               {/* FX Rate (moved here) */}
-              <div className="grid grid-cols-2 gap-4">
-                <div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 min-w-0">
+                <div className="min-w-0">
                   <Label className="font-bold text-red-600">{t('f4.preview.labels.fx_rate')} *</Label>
                   <p className="text-xs text-muted-foreground mt-0.5 mb-1.5 max-w-md">
                     {t('f4.preview.labels.fx_rate_note')}
@@ -1192,7 +1191,7 @@ export default function UploadF4Modal({ open, onOpenChange, onSaved, initialProj
             </div>
 
             {/* Expenses (move above Financials) */}
-            <div>
+            <div className="min-w-0 max-w-full">
               <div className="flex items-center justify-between mb-2">
                 <Label>{t('f4.preview.expenses.title')}</Label>
                 <Button
@@ -1221,24 +1220,24 @@ export default function UploadF4Modal({ open, onOpenChange, onSaved, initialProj
             </div>
 
             {/* Financials */}
-            <div className="grid grid-cols-2 gap-4">
-              <div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 min-w-0">
+              <div className="min-w-0">
                 <Label>{t('f4.preview.financials.total_grant')} (USD)</Label>
                 <div className="h-10 flex items-center px-3 rounded border bg-muted/50">{(projectMeta?.total_grant_from_project ?? 0).toLocaleString()}</div>
               </div>
-              <div>
+              <div className="min-w-0">
                 <Label>{t('f4.preview.financials.total_expenses')} (USD)</Label>
                 <div className="h-10 flex items-center px-3 rounded border bg-muted/50">{expensesDraft.reduce((s, ex) => s + (Number(ex.expense_amount) || 0), 0).toLocaleString()}</div>
               </div>
-              <div>
+              <div className="min-w-0">
                 <Label>{t('f4.preview.financials.total_expenses')} (SDG)</Label>
                 <div className="h-10 flex items-center px-3 rounded border bg-muted/50">{expensesDraft.reduce((s, ex) => s + (Number(ex.expense_amount_sdg) || 0), 0).toLocaleString()}</div>
               </div>
-              <div>
+              <div className="min-w-0">
                 <Label>{t('f4.preview.financials.remainder')} (USD)</Label>
                 <Input className="select-text" type="number" value={String((projectMeta?.total_grant_from_project || 0) - expensesDraft.reduce((s, ex) => s + (Number(ex.expense_amount) || 0), 0))} readOnly />
               </div>
-              <div>
+              <div className="min-w-0">
                 <Label>{t('f4.preview.financials.total_other_sources')}</Label>
                 <Input 
                   className="select-text selection:bg-blue-200 selection:text-blue-900 dark:selection:bg-blue-800 dark:selection:text-blue-100" 
@@ -1251,7 +1250,7 @@ export default function UploadF4Modal({ open, onOpenChange, onSaved, initialProj
                   onChange={(e)=>setSummaryDraft((s:any)=>({ ...(s||{}), total_other_sources: parseFloat(e.target.value)||0 }))} 
                 />
               </div>
-              <div className="col-span-2">
+              <div className="sm:col-span-2 min-w-0">
                 <Label>{t('f4.preview.financials.excess_expenses')}</Label>
                 <Textarea 
                   className="select-text selection:bg-blue-200 selection:text-blue-900 dark:selection:bg-blue-800 dark:selection:text-blue-100 min-h-[100px]" 
@@ -1260,7 +1259,7 @@ export default function UploadF4Modal({ open, onOpenChange, onSaved, initialProj
                   onChange={(e)=>setSummaryDraft((s:any)=>({ ...(s||{}), excess_expenses: e.target.value }))} 
                 />
               </div>
-              <div className="col-span-2">
+              <div className="sm:col-span-2 min-w-0">
                 <Label>{t('f4.preview.financials.surplus_use')}</Label>
                 <Textarea 
                   className="select-text selection:bg-blue-200 selection:text-blue-900 dark:selection:bg-blue-800 dark:selection:text-blue-100 min-h-[100px]" 
@@ -1269,7 +1268,7 @@ export default function UploadF4Modal({ open, onOpenChange, onSaved, initialProj
                   onChange={(e)=>setSummaryDraft((s:any)=>({ ...(s||{}), surplus_use: e.target.value }))} 
                 />
               </div>
-              <div className="col-span-2">
+              <div className="sm:col-span-2 min-w-0">
                 <Label>{t('f4.preview.financials.lessons_learned')}</Label>
                 <Textarea 
                   className="select-text selection:bg-blue-200 selection:text-blue-900 dark:selection:bg-blue-800 dark:selection:text-blue-100 min-h-[100px]" 
@@ -1278,7 +1277,7 @@ export default function UploadF4Modal({ open, onOpenChange, onSaved, initialProj
                   onChange={(e)=>setSummaryDraft((s:any)=>({ ...(s||{}), lessons: e.target.value }))} 
                 />
               </div>
-              <div className="col-span-2">
+              <div className="sm:col-span-2 min-w-0">
                 <Label>{t('f4.preview.financials.training_needs')}</Label>
                 <Textarea 
                   className="select-text selection:bg-blue-200 selection:text-blue-900 dark:selection:bg-blue-800 dark:selection:text-blue-100 min-h-[100px]" 
@@ -1288,7 +1287,7 @@ export default function UploadF4Modal({ open, onOpenChange, onSaved, initialProj
                 />
               </div>
 
-              <div className="col-span-2 rounded border p-3 bg-muted/20 space-y-3">
+              <div className="sm:col-span-2 min-w-0 rounded border p-3 bg-muted/20 space-y-3">
                 <div className="font-medium text-sm">Receipt Check</div>
                 {(() => {
                   const receiptRows = Array.isArray(summaryDraft?.receipt_check?.receipts) ? summaryDraft.receipt_check.receipts : []
@@ -1317,27 +1316,36 @@ export default function UploadF4Modal({ open, onOpenChange, onSaved, initialProj
                       <div className="text-xs text-muted-foreground">
                         Edit extracted receipt amounts as needed, add missing receipts manually, or mark unreadable receipts as missing.
                       </div>
-                      <div className="border rounded overflow-hidden bg-background">
-                        <Table>
-                          <TableHeader>
-                            <TableRow>
-                              <TableHead className="w-[40%]">Receipt / Reference</TableHead>
-                              <TableHead className="w-[25%]">Amount (SDG)</TableHead>
-                              <TableHead className="w-[20%]">Missing</TableHead>
-                              <TableHead className="w-[15%] text-right">Actions</TableHead>
-                            </TableRow>
-                          </TableHeader>
-                          <TableBody>
-                            {receiptRows.length === 0 ? (
-                              <TableRow>
-                                <TableCell colSpan={4} className="text-sm text-muted-foreground">
-                                  No receipt rows yet. Add rows manually if needed.
-                                </TableCell>
-                              </TableRow>
-                            ) : (
-                              receiptRows.map((row: any, idx: number) => (
-                                <TableRow key={`receipt-row-${idx}`}>
-                                  <TableCell>
+                      <div className="bg-background">
+                        {receiptRows.length === 0 ? (
+                          <div className="border rounded p-3 text-sm text-muted-foreground">
+                            No receipt rows yet. Add rows manually if needed.
+                          </div>
+                        ) : (
+                          <>
+                            {/* Receipt rows — stacked cards on all widths (no horizontal scroll) */}
+                            <div className="space-y-3">
+                              {receiptRows.map((row: any, idx: number) => (
+                                <div key={`receipt-card-${idx}`} className="rounded-lg border p-3 space-y-3 min-w-0">
+                                  <div className="flex items-center justify-between gap-2">
+                                    <span className="text-xs font-semibold text-muted-foreground">#{idx + 1}</span>
+                                    <Button
+                                      variant="destructive"
+                                      size="sm"
+                                      onClick={() => {
+                                        const nextRows = [...receiptRows]
+                                        nextRows.splice(idx, 1)
+                                        setSummaryDraft((s: any) => ({
+                                          ...(s || {}),
+                                          receipt_check: { ...(s?.receipt_check || {}), receipts: nextRows, confirmed: false },
+                                        }))
+                                      }}
+                                    >
+                                      Delete
+                                    </Button>
+                                  </div>
+                                  <div className="space-y-1.5 min-w-0">
+                                    <Label className="text-xs text-muted-foreground">Receipt / Reference</Label>
                                     <F4ExpandableTextInput
                                       value={row?.reference || ''}
                                       onChange={(v) => {
@@ -1350,24 +1358,25 @@ export default function UploadF4Modal({ open, onOpenChange, onSaved, initialProj
                                       }}
                                       placeholder={`receipt-${idx + 1}`}
                                     />
-                                  </TableCell>
-                                  <TableCell>
-                                    <F4FormattedAmountInput
-                                      value={row?.amount_sdg != null ? Number(row.amount_sdg) : null}
-                                      onChange={(num) => {
-                                        const nextRows = [...receiptRows]
-                                        nextRows[idx] = { ...nextRows[idx], amount_sdg: num }
-                                        setSummaryDraft((s: any) => ({
-                                          ...(s || {}),
-                                          receipt_check: { ...(s?.receipt_check || {}), receipts: nextRows, confirmed: false },
-                                        }))
-                                      }}
-                                      placeholder="0"
-                                      disabled={Boolean(row?.missing)}
-                                    />
-                                  </TableCell>
-                                  <TableCell>
-                                    <div className="flex items-center gap-2">
+                                  </div>
+                                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 min-w-0">
+                                    <div className="space-y-1.5 min-w-0">
+                                      <Label className="text-xs text-muted-foreground">Amount (SDG)</Label>
+                                      <F4FormattedAmountInput
+                                        value={row?.amount_sdg != null ? Number(row.amount_sdg) : null}
+                                        onChange={(num) => {
+                                          const nextRows = [...receiptRows]
+                                          nextRows[idx] = { ...nextRows[idx], amount_sdg: num }
+                                          setSummaryDraft((s: any) => ({
+                                            ...(s || {}),
+                                            receipt_check: { ...(s?.receipt_check || {}), receipts: nextRows, confirmed: false },
+                                          }))
+                                        }}
+                                        placeholder="0"
+                                        disabled={Boolean(row?.missing)}
+                                      />
+                                    </div>
+                                    <div className="flex items-end gap-2 pb-1">
                                       <Checkbox
                                         checked={Boolean(row?.missing)}
                                         onCheckedChange={(checked) => {
@@ -1385,28 +1394,12 @@ export default function UploadF4Modal({ open, onOpenChange, onSaved, initialProj
                                       />
                                       <span className="text-xs text-muted-foreground">mark missing</span>
                                     </div>
-                                  </TableCell>
-                                  <TableCell className="text-right">
-                                    <Button
-                                      variant="destructive"
-                                      size="sm"
-                                      onClick={() => {
-                                        const nextRows = [...receiptRows]
-                                        nextRows.splice(idx, 1)
-                                        setSummaryDraft((s: any) => ({
-                                          ...(s || {}),
-                                          receipt_check: { ...(s?.receipt_check || {}), receipts: nextRows, confirmed: false },
-                                        }))
-                                      }}
-                                    >
-                                      Delete
-                                    </Button>
-                                  </TableCell>
-                                </TableRow>
-                              ))
-                            )}
-                          </TableBody>
-                        </Table>
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          </>
+                        )}
                       </div>
                       <div>
                         <Button

--- a/src/app/err-portal/f4-f5-reporting/components/ViewF4Modal.tsx
+++ b/src/app/err-portal/f4-f5-reporting/components/ViewF4Modal.tsx
@@ -368,8 +368,8 @@ export default function ViewF4Modal({ summaryId, open, onOpenChange, onSaved }: 
             </div>
 
             {/* Summary */}
-            <div className="grid grid-cols-2 gap-4">
-              <div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 min-w-0">
+              <div className="min-w-0">
                 <Label>Report Date</Label>
                 {isEditing ? (
                   <Input type="date" value={summaryDraft?.report_date ? (typeof summaryDraft.report_date === 'string' ? summaryDraft.report_date.split('T')[0] : new Date(summaryDraft.report_date).toISOString().split('T')[0]) : ''} onChange={(e)=>setSummaryDraft((s:any)=>({ ...(s||{}), report_date: e.target.value }))} />
@@ -377,7 +377,7 @@ export default function ViewF4Modal({ summaryId, open, onOpenChange, onSaved }: 
                   <div className="h-10 flex items-center px-3 rounded border bg-muted/50">{reportDateDisplay}</div>
                 )}
               </div>
-              <div className={!isEditing ? 'col-span-2' : ''}>
+              <div className={`min-w-0${!isEditing ? ' sm:col-span-2' : ''}`}>
                 <Label>Beneficiaries</Label>
                 {isEditing ? (
                   <Input value={summaryDraft?.beneficiaries || ''} onChange={(e)=>setSummaryDraft((s:any)=>({ ...(s||{}), beneficiaries: e.target.value }))} />
@@ -389,8 +389,8 @@ export default function ViewF4Modal({ summaryId, open, onOpenChange, onSaved }: 
 
             {/* FX Rate */}
             {isEditing && (
-              <div className="grid grid-cols-2 gap-4">
-                <div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 min-w-0">
+                <div className="min-w-0">
                   <Label>{t('f4.preview.labels.fx_rate')}</Label>
                   <Input type="number" value={fxRate ?? ''} onChange={(e)=>{
                     const v = parseFloat(e.target.value)
@@ -414,24 +414,24 @@ export default function ViewF4Modal({ summaryId, open, onOpenChange, onSaved }: 
             )}
 
             {/* Financials */}
-            <div className="grid grid-cols-2 gap-4">
-              <div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 min-w-0">
+              <div className="min-w-0">
                 <Label>{t('f4.preview.financials.total_grant')} (USD)</Label>
                 <div className="h-10 flex items-center px-3 rounded border bg-muted/50">{(projectMeta?.total_grant_from_project ?? summary?.total_grant ?? 0).toLocaleString()}</div>
               </div>
-              <div>
+              <div className="min-w-0">
                 <Label>{t('f4.preview.financials.total_expenses')} (USD)</Label>
                 <div className="h-10 flex items-center px-3 rounded border bg-muted/50">{expensesDraft.reduce((s, ex) => s + (Number(ex.expense_amount) || 0), 0).toLocaleString()}</div>
               </div>
-              <div>
+              <div className="min-w-0">
                 <Label>{t('f4.preview.financials.total_expenses')} (SDG)</Label>
                 <div className="h-10 flex items-center px-3 rounded border bg-muted/50">{expensesDraft.reduce((s, ex) => s + (Number(ex.expense_amount_sdg) || 0), 0).toLocaleString()}</div>
               </div>
-              <div>
+              <div className="min-w-0">
                 <Label>{t('f4.preview.financials.remainder')} (USD)</Label>
                 <Input type="number" value={(projectMeta?.total_grant_from_project ?? summary?.total_grant ?? 0) - expensesDraft.reduce((s, ex) => s + (Number(ex.expense_amount) || 0), 0)} readOnly />
               </div>
-              <div>
+              <div className="min-w-0">
                 <Label>{t('f4.preview.financials.total_other_sources')}</Label>
                 {isEditing ? (
                   <Input type="number" value={summaryDraft?.total_other_sources ?? ''} onChange={(e)=>setSummaryDraft((s:any)=>({ ...(s||{}), total_other_sources: parseFloat(e.target.value)||0 }))} />
@@ -441,8 +441,8 @@ export default function ViewF4Modal({ summaryId, open, onOpenChange, onSaved }: 
               </div>
             </div>
 
-            <div className="grid grid-cols-2 gap-4">
-              <div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 min-w-0">
+              <div className="min-w-0">
                 <Label>Excess Expenses (How covered?)</Label>
                 {isEditing ? (
                   <Input value={summaryDraft?.excess_expenses || ''} onChange={(e)=>setSummaryDraft((s:any)=>({ ...(s||{}), excess_expenses: e.target.value }))} />
@@ -450,7 +450,7 @@ export default function ViewF4Modal({ summaryId, open, onOpenChange, onSaved }: 
                   <div className="min-h-[40px] max-h-[10rem] overflow-y-auto px-3 py-2 rounded border bg-muted/50 text-sm whitespace-pre-wrap break-words">{summary?.excess_expenses || '-'}</div>
                 )}
               </div>
-              <div>
+              <div className="min-w-0">
                 <Label>Surplus Use</Label>
                 {isEditing ? (
                   <Input value={summaryDraft?.surplus_use || ''} onChange={(e)=>setSummaryDraft((s:any)=>({ ...(s||{}), surplus_use: e.target.value }))} />
@@ -458,7 +458,7 @@ export default function ViewF4Modal({ summaryId, open, onOpenChange, onSaved }: 
                   <div className="min-h-[40px] max-h-[10rem] overflow-y-auto px-3 py-2 rounded border bg-muted/50 text-sm whitespace-pre-wrap break-words">{summary?.surplus_use || '-'}</div>
                 )}
               </div>
-              <div>
+              <div className="min-w-0">
                 <Label>Lessons Learned</Label>
                 {isEditing ? (
                   <Input value={summaryDraft?.lessons || ''} onChange={(e)=>setSummaryDraft((s:any)=>({ ...(s||{}), lessons: e.target.value }))} />
@@ -466,7 +466,7 @@ export default function ViewF4Modal({ summaryId, open, onOpenChange, onSaved }: 
                   <div className="min-h-[40px] max-h-[10rem] overflow-y-auto px-3 py-2 rounded border bg-muted/50 text-sm whitespace-pre-wrap break-words">{lessonsDisplay}</div>
                 )}
               </div>
-              <div>
+              <div className="min-w-0">
                 <Label>Training Needs</Label>
                 {isEditing ? (
                   <Input value={summaryDraft?.training || ''} onChange={(e)=>setSummaryDraft((s:any)=>({ ...(s||{}), training: e.target.value }))} />
@@ -477,7 +477,7 @@ export default function ViewF4Modal({ summaryId, open, onOpenChange, onSaved }: 
             </div>
 
             {/* Expenses */}
-            <div>
+            <div className="min-w-0 max-w-full">
               <div className="flex items-center justify-between mb-2">
                 <Label>Expenses</Label>
                 {isEditing && (

--- a/src/app/err-portal/f4-f5-reporting/components/ViewF4Modal.tsx
+++ b/src/app/err-portal/f4-f5-reporting/components/ViewF4Modal.tsx
@@ -5,11 +5,9 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogD
 import { Label } from '@/components/ui/label'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
-import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { supabase } from '@/lib/supabaseClient'
 import { fetchF4SectorsForMatch, normalizeF4ExpenseActivitiesToSectors, type F4SectorRow } from '@/lib/f4ExpenseSectors'
-import { F4ExpenseSectorSelect } from './F4ExpenseSectorSelect'
+import { F4ExpensesEditableTable } from './F4ExpensesEditableTable'
 import { useTranslation } from 'react-i18next'
 import { FileText } from 'lucide-react'
 
@@ -499,148 +497,14 @@ export default function ViewF4Modal({ summaryId, open, onOpenChange, onSaved }: 
                   >Add Expense</Button>
                 )}
               </div>
-              <div className="border rounded overflow-hidden">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead className="w-[14%] py-1 px-2 text-xs">Activity</TableHead>
-                      <TableHead className="w-[20%] py-1 px-2 text-xs">Description</TableHead>
-                      <TableHead className="w-[10%] py-1 px-2 text-right text-xs">Amount (SDG)</TableHead>
-                      <TableHead className="w-[10%] py-1 px-2 text-right text-xs">Amount (USD)</TableHead>
-                      <TableHead className="w-[12%] py-1 px-2 text-xs">Payment Date</TableHead>
-                      <TableHead className="w-[10%] py-1 px-2 text-xs">Method</TableHead>
-                      <TableHead className="w-[10%] py-1 px-2 text-xs">Receipt</TableHead>
-                      <TableHead className="w-[14%] py-1 px-2 text-xs">Seller</TableHead>
-                      {isEditing && <TableHead className="w-[8%] py-1 px-2 text-xs text-right">Actions</TableHead>}
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {expensesDraft.length === 0 ? (
-                      <TableRow><TableCell colSpan={isEditing ? 9 : 8} className="text-muted-foreground text-center">No expenses</TableCell></TableRow>
-                    ) : expensesDraft.map((ex, idx) => (
-                      <TableRow key={ex.expense_id || idx}>
-                        <TableCell className="py-1 px-2">
-                          {isEditing ? (
-                            <F4ExpenseSectorSelect
-                              sectors={f4Sectors}
-                              valueEn={ex.expense_activity || ''}
-                              onChangeEn={(sectorNameEn) => {
-                                const arr = [...expensesDraft]
-                                arr[idx] = { ...arr[idx], expense_activity: sectorNameEn }
-                                setExpensesDraft(arr)
-                              }}
-                              placeholder={t('f4.preview.expenses.sector_placeholder') as string}
-                              className="h-8 w-full"
-                            />
-                          ) : (
-                            ex.expense_activity || '-'
-                          )}
-                        </TableCell>
-                        <TableCell className="py-1 px-2">
-                          {isEditing ? (
-                            <Input className="h-8" value={ex.expense_description || ''} onChange={(e)=>{
-                              const arr=[...expensesDraft]; arr[idx]={...arr[idx], expense_description: e.target.value}; setExpensesDraft(arr)
-                            }} />
-                          ) : (
-                            ex.expense_description || '-'
-                          )}
-                        </TableCell>
-                        <TableCell className="py-1 px-2 text-right">
-                          {isEditing ? (
-                            <Input className="h-8" type="number" placeholder="SDG" value={ex.expense_amount_sdg ?? ''} onChange={(e)=>{
-                              const enteredValue = parseFloat(e.target.value) || 0
-                              const arr = [...expensesDraft]
-                              arr[idx] = {
-                                ...arr[idx],
-                                expense_amount_sdg: enteredValue || null,
-                                // Auto-calculate USD if exchange rate is set
-                                expense_amount: (fxRate && fxRate > 0 && enteredValue > 0) ? +(enteredValue / fxRate).toFixed(2) : arr[idx].expense_amount
-                              }
-                              setExpensesDraft(arr)
-                            }} />
-                          ) : (
-                            Number(ex.expense_amount_sdg || 0).toLocaleString()
-                          )}
-                        </TableCell>
-                        <TableCell className="py-1 px-2 text-right">
-                          {isEditing ? (
-                            <Input className="h-8" type="number" placeholder="USD" value={ex.expense_amount ?? ''} onChange={(e)=>{
-                              const enteredValue = parseFloat(e.target.value) || 0
-                              const arr = [...expensesDraft]
-                              arr[idx] = {
-                                ...arr[idx],
-                                expense_amount: enteredValue || null,
-                                // Auto-calculate SDG if exchange rate is set
-                                expense_amount_sdg: (fxRate && fxRate > 0 && enteredValue > 0) ? +(enteredValue * fxRate).toFixed(2) : arr[idx].expense_amount_sdg
-                              }
-                              setExpensesDraft(arr)
-                            }} />
-                          ) : (
-                            Number(ex.expense_amount || 0).toLocaleString()
-                          )}
-                        </TableCell>
-                        <TableCell className="py-1 px-2">
-                          {isEditing ? (
-                            <Input className="h-8" type="date" value={ex.payment_date || ''} onChange={(e)=>{
-                              const arr=[...expensesDraft]; arr[idx]={...arr[idx], payment_date: e.target.value}; setExpensesDraft(arr)
-                            }} />
-                          ) : (
-                            ex.payment_date ? new Date(ex.payment_date).toLocaleDateString() : '-'
-                          )}
-                        </TableCell>
-                        <TableCell className="py-1 px-2">
-                          {isEditing ? (
-                            <Select value={ex.payment_method || 'Bank Transfer'} onValueChange={(v)=>{
-                              const arr=[...expensesDraft]; arr[idx]={...arr[idx], payment_method: v}; setExpensesDraft(arr)
-                            }}>
-                              <SelectTrigger className="h-8 w-full">
-                                <SelectValue />
-                              </SelectTrigger>
-                              <SelectContent>
-                                <SelectItem value="Bank Transfer">Bank Transfer</SelectItem>
-                                <SelectItem value="Cash">Cash</SelectItem>
-                              </SelectContent>
-                            </Select>
-                          ) : (
-                            ex.payment_method || '-'
-                          )}
-                        </TableCell>
-                        <TableCell className="py-1 px-2">
-                          {isEditing ? (
-                            <Input className="h-8" value={ex.receipt_no || ''} onChange={(e)=>{
-                              const arr=[...expensesDraft]; arr[idx]={...arr[idx], receipt_no: e.target.value}; setExpensesDraft(arr)
-                            }} />
-                          ) : (
-                            ex.receipt_no || '-'
-                          )}
-                        </TableCell>
-                        <TableCell className="py-1 px-2">
-                          {isEditing ? (
-                            <Input className="h-8" value={ex.seller || ''} onChange={(e)=>{
-                              const arr=[...expensesDraft]; arr[idx]={...arr[idx], seller: e.target.value}; setExpensesDraft(arr)
-                            }} />
-                          ) : (
-                            ex.seller || '-'
-                          )}
-                        </TableCell>
-                        {isEditing && (
-                          <TableCell className="py-1 px-2 text-right">
-                            <Button
-                              variant="destructive"
-                              size="sm"
-                              onClick={() => {
-                                const arr = [...expensesDraft]
-                                arr.splice(idx, 1)
-                                setExpensesDraft(arr)
-                              }}
-                            >Delete</Button>
-                          </TableCell>
-                        )}
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
+              <F4ExpensesEditableTable
+                expenses={expensesDraft}
+                onChange={setExpensesDraft}
+                sectors={f4Sectors}
+                fxRate={fxRate}
+                editable={isEditing}
+                emptyLabel="No expenses"
+              />
             </div>
 
             {/* Attachments */}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import * as React from 'react'
+import * as PopoverPrimitive from '@radix-ui/react-popover'
+import { cn } from '@/lib/utils'
+
+function Popover ({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger ({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent ({
+  className,
+  align = 'start',
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'bg-popover text-popover-foreground z-[100] w-72 rounded-md border p-3 shadow-md outline-none',
+          'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+export { Popover, PopoverTrigger, PopoverContent }

--- a/src/i18n/locales/ar/f4f5.json
+++ b/src/i18n/locales/ar/f4f5.json
@@ -97,6 +97,7 @@
         "empty": "لا توجد مصروفات مستخرجة",
         "add": "إضافة مصروف",
         "sector_placeholder": "اختر القطاع",
+        "fill_down": "تعبئة لأسفل",
         "popover_cancel": "إلغاء",
         "popover_apply": "تطبيق",
         "cols": {

--- a/src/i18n/locales/ar/f4f5.json
+++ b/src/i18n/locales/ar/f4f5.json
@@ -97,6 +97,8 @@
         "empty": "لا توجد مصروفات مستخرجة",
         "add": "إضافة مصروف",
         "sector_placeholder": "اختر القطاع",
+        "popover_cancel": "إلغاء",
+        "popover_apply": "تطبيق",
         "cols": {
           "activity": "النشاط",
           "description": "الوصف",

--- a/src/i18n/locales/en/f4f5.json
+++ b/src/i18n/locales/en/f4f5.json
@@ -97,6 +97,8 @@
         "empty": "No expenses parsed",
         "add": "Add expense",
         "sector_placeholder": "Select sector",
+        "popover_cancel": "Cancel",
+        "popover_apply": "Apply",
         "cols": {
           "activity": "Activity",
           "description": "Description",

--- a/src/i18n/locales/en/f4f5.json
+++ b/src/i18n/locales/en/f4f5.json
@@ -97,6 +97,7 @@
         "empty": "No expenses parsed",
         "add": "Add expense",
         "sector_placeholder": "Select sector",
+        "fill_down": "Fill Down",
         "popover_cancel": "Cancel",
         "popover_apply": "Apply",
         "cols": {

--- a/src/lib/f4ExpenseUi.ts
+++ b/src/lib/f4ExpenseUi.ts
@@ -1,0 +1,132 @@
+/** UI helpers for F4 expense table: colors, amount formatting, fill keys. */
+
+export type F4ExpenseFillKey =
+  | 'expense_activity'
+  | 'expense_amount_sdg'
+  | 'expense_amount'
+  | 'payment_date'
+  | 'payment_method'
+  | 'receipt_no'
+
+export const F4_FILLABLE_KEYS: F4ExpenseFillKey[] = [
+  'expense_activity',
+  'expense_amount_sdg',
+  'expense_amount',
+  'payment_date',
+  'payment_method',
+  'receipt_no',
+]
+
+function normKey (s: string): string {
+  return s.trim().toLowerCase().replace(/\s+/g, ' ')
+}
+
+/** Pill colors keyed by English sector name (stable across locale). */
+const SECTOR_PILL_BY_NORM: Record<string, string> = {
+  livelihoods: 'bg-[#FDD835] text-black border-transparent',
+  'capacity building': 'bg-[#7B1FA2] text-white border-transparent',
+  education: 'bg-[#0D47A1] text-white border-transparent',
+  'mental and physical health': 'bg-[#E0E0E0] text-black border-transparent',
+  'protection - evacuation': 'bg-[#E53935] text-black border-transparent',
+  evacuation: 'bg-[#E53935] text-black border-transparent',
+  'the needs of women and children': 'bg-[#EC407A] text-black border-transparent',
+  'volunteer support': 'bg-[#FB8C00] text-black border-transparent',
+  'volunteers support': 'bg-[#FB8C00] text-black border-transparent',
+  'support logistic operations': 'bg-[#CFD8DC] text-black border-transparent',
+  'health - medical supplies': 'bg-[#C62828] text-white border-transparent',
+  'health support': 'bg-[#C62828] text-white border-transparent',
+  'food security': 'bg-[#1B5E20] text-white border-transparent',
+  'food baskets': 'bg-[#1B5E20] text-white border-transparent',
+  wash: 'bg-[#29B6F6] text-black border-transparent',
+  'peacebuilding / social cohesion': 'bg-[#1565C0] text-white border-transparent',
+  'peacebuilding/social cohesion': 'bg-[#1565C0] text-white border-transparent',
+  'youth space': 'bg-[#43A047] text-black border-transparent',
+  'socioeconomic empowerment': 'bg-[#607D8B] text-white border-transparent',
+  'agriculture support': 'bg-[#C8E6C9] text-[#1B5E20] border-transparent',
+  infrastructure: 'bg-[#FFF8E1] text-[#5D4037] border-transparent',
+  flexible: 'bg-[#ECEFF1] text-black border-transparent',
+  'shelter centers': 'bg-[#8D6E63] text-white border-transparent',
+  'community kitchen': 'bg-[#FF7043] text-black border-transparent',
+  'alternative education': 'bg-[#5C6BC0] text-white border-transparent',
+  communications: 'bg-[#26A69A] text-black border-transparent',
+  other: 'bg-[#BDBDBD] text-black border-transparent',
+}
+
+const DEFAULT_SECTOR_PILL = 'bg-muted text-foreground border-border'
+
+export function sectorPillClassName (sectorNameEn: string | null | undefined): string {
+  if (!sectorNameEn?.trim()) return DEFAULT_SECTOR_PILL
+  return SECTOR_PILL_BY_NORM[normKey(sectorNameEn)] || DEFAULT_SECTOR_PILL
+}
+
+export const PAYMENT_METHOD_OPTIONS = ['Bank Transfer', 'Cash'] as const
+export type F4PaymentMethod = (typeof PAYMENT_METHOD_OPTIONS)[number]
+
+const PAYMENT_PILL: Record<string, string> = {
+  'bank transfer': 'bg-[#1565C0] text-white border-transparent',
+  cash: 'bg-[#43A047] text-white border-transparent',
+}
+
+export function paymentMethodPillClassName (method: string | null | undefined): string {
+  if (!method?.trim()) return DEFAULT_SECTOR_PILL
+  return PAYMENT_PILL[normKey(method)] || DEFAULT_SECTOR_PILL
+}
+
+export function formatAmountDisplay (
+  value: number | null | undefined,
+  locale: string,
+  opts?: { maxFractionDigits?: number }
+): string {
+  if (value == null || !Number.isFinite(Number(value))) return ''
+  const n = Number(value)
+  const max = opts?.maxFractionDigits ?? (Number.isInteger(n) ? 0 : 2)
+  return n.toLocaleString(locale.startsWith('ar') ? 'en-US' : locale, {
+    maximumFractionDigits: max,
+    minimumFractionDigits: 0,
+  })
+}
+
+/** Strip grouping separators; keep digits, optional leading minus, and one decimal point. */
+export function parseAmountInput (raw: string): number | null {
+  const cleaned = String(raw || '')
+    .replace(/[\u0660-\u0669]/g, (d) => String(d.charCodeAt(0) - 0x0660))
+    .replace(/,/g, '')
+    .replace(/\s/g, '')
+    .trim()
+  if (!cleaned || cleaned === '-' || cleaned === '.') return null
+  const n = Number(cleaned)
+  if (!Number.isFinite(n)) return null
+  return n
+}
+
+export function applyExpenseFill (
+  rows: Array<Record<string, any>>,
+  key: F4ExpenseFillKey,
+  fromRow: number,
+  toRow: number,
+  fxRate: number | null
+): Array<Record<string, any>> {
+  if (fromRow < 0 || toRow < 0 || fromRow >= rows.length || toRow >= rows.length) return rows
+  const lo = Math.min(fromRow, toRow)
+  const hi = Math.max(fromRow, toRow)
+  if (lo === hi) return rows
+  const source = rows[fromRow]
+  const next = rows.map((r) => ({ ...r }))
+  for (let i = lo; i <= hi; i++) {
+    if (i === fromRow) continue
+    next[i] = { ...next[i], [key]: source[key] }
+    if (key === 'expense_amount_sdg' && fxRate && fxRate > 0) {
+      const sdg = Number(source.expense_amount_sdg)
+      if (Number.isFinite(sdg) && sdg > 0) {
+        next[i].expense_amount = +(sdg / fxRate).toFixed(2)
+      }
+    }
+    if (key === 'expense_amount' && fxRate && fxRate > 0) {
+      const usd = Number(source.expense_amount)
+      if (Number.isFinite(usd) && usd > 0) {
+        next[i].expense_amount_sdg = +(usd * fxRate).toFixed(2)
+      }
+    }
+  }
+  return next
+}


### PR DESCRIPTION
## Summary
- Shared editable F4 expenses table with colored sector/payment pills, locale-aware sector labels, live thousand separators, expand-on-focus description/seller fields, and fill-down (pointer drag handle + touch Fill Down via input capability, not viewport breakpoints).
- Horizontal scroll confined to the expenses grid with a sticky first column; summary/financials and receipt check sections use responsive stacked layouts without page-level horizontal scroll.
- Upload and View F4 modals wired to the shared table; adds Radix Popover UI primitive and `f4ExpenseUi` helpers.

## Test plan
- [ ] Upload F4 → expenses table: edit sector/description/amounts/seller; confirm commas while typing and expand-on-focus text fields.
- [ ] Desktop/mouse (including narrow split panel): drag Fill Handle works; Fill Down button hidden when fine pointer is available.
- [ ] Touch / coarse pointer: Fill Down fills column to last row using same fill logic.
- [ ] Narrow viewport: expenses table scrolls horizontally only inside the grid; first column stays sticky; summary/financials/receipts stack without horizontal page scroll.
- [ ] View F4 edit mode uses the same table behavior; save still persists expenses correctly.