### PR TITLE
Data Archive feedback: completion dates, grant names, filter harden

### DIFF
--- a/sql/add_completed_at_to_err_projects.sql
+++ b/sql/add_completed_at_to_err_projects.sql
@@ -5,3 +5,10 @@ ALTER TABLE err_projects
   ADD COLUMN IF NOT EXISTS completed_at timestamptz;
 
 COMMENT ON COLUMN err_projects.completed_at IS 'When status was set to completed (used by Data Archive exports). NULL for legacy completions until amended.';
+
+-- Backfill from the existing report-completion date for projects already marked completed.
+UPDATE err_projects
+SET completed_at = (date_report_completed::timestamptz)
+WHERE status = 'completed'
+  AND completed_at IS NULL
+  AND date_report_completed IS NOT NULL;

--- a/src/app/api/data-archive/completed/route.ts
+++ b/src/app/api/data-archive/completed/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
-import { getSupabaseRouteClient } from '@/lib/supabaseRouteClient'
 import { requirePermission } from '@/lib/requirePermission'
+import { getSupabaseAdmin } from '@/lib/supabaseAdmin'
 import { collectArchiveFiles, type ArchiveProjectRow } from '@/lib/dataArchive'
 import { resolveProjectCompletionDate } from '@/lib/projectStatus'
 
@@ -21,16 +21,16 @@ const PROJECT_SELECT = `
   grant_calls ( id, name, shortname )
 `
 
+const PAGE = 1000
+
 /** Resolve month=YYYY-MM or from/to (inclusive dates) into an ISO [start, end) range. */
-function resolveRange(url: URL): { start: string; end: string; startDate: string; endDate: string } | null {
+function resolveRange(url: URL): { start: string; end: string } | null {
   const month = url.searchParams.get('month')
   if (month && /^\d{4}-\d{2}$/.test(month)) {
     const [y, m] = month.split('-').map(Number)
     const start = new Date(Date.UTC(y, m - 1, 1))
     const end = new Date(Date.UTC(y, m, 1))
-    const startDate = start.toISOString().slice(0, 10)
-    const endDate = end.toISOString().slice(0, 10)
-    return { start: start.toISOString(), end: end.toISOString(), startDate, endDate }
+    return { start: start.toISOString(), end: end.toISOString() }
   }
   const from = url.searchParams.get('from')
   const to = url.searchParams.get('to')
@@ -39,12 +39,7 @@ function resolveRange(url: URL): { start: string; end: string; startDate: string
     const endExclusive = new Date(`${to}T00:00:00.000Z`)
     endExclusive.setUTCDate(endExclusive.getUTCDate() + 1)
     if (!isNaN(start.getTime()) && !isNaN(endExclusive.getTime())) {
-      return {
-        start: start.toISOString(),
-        end: endExclusive.toISOString(),
-        startDate: from,
-        endDate: endExclusive.toISOString().slice(0, 10)
-      }
+      return { start: start.toISOString(), end: endExclusive.toISOString() }
     }
   }
   return null
@@ -55,47 +50,46 @@ function grantNameLabel(p: any): string | null {
   return p.grant_calls?.name || p.donors?.name || null
 }
 
+async function fetchAllCompleted(supabase: ReturnType<typeof getSupabaseAdmin>, grantCallId: string | null) {
+  const projects: any[] = []
+  for (let from = 0; ; from += PAGE) {
+    let query = supabase
+      .from('err_projects')
+      .select(PROJECT_SELECT)
+      .eq('status', 'completed')
+      .order('id', { ascending: true })
+      .range(from, from + PAGE - 1)
+    if (grantCallId) query = query.eq('grant_call_id', grantCallId)
+    const { data, error } = await query
+    if (error) throw error
+    projects.push(...(data || []))
+    if (!data || data.length < PAGE) break
+  }
+  return projects
+}
+
 export async function GET(req: Request) {
   const perm = await requirePermission('data_archive_view_page')
   if (perm instanceof NextResponse) return perm
 
   try {
-    const supabase = getSupabaseRouteClient()
+    // Use admin after permission check so date filters are not affected by RLS quirks.
+    const supabase = getSupabaseAdmin()
     const url = new URL(req.url)
     const range = resolveRange(url)
     const includeUndated = url.searchParams.get('include_undated') === 'true'
     const grantCallId = url.searchParams.get('grant_call_id')
 
-    let query = supabase
-      .from('err_projects')
-      .select(PROJECT_SELECT)
-      .eq('status', 'completed')
+    const projects = await fetchAllCompleted(supabase, grantCallId)
 
-    if (range) {
-      // Match either completed_at (new) or date_report_completed (legacy / report date).
-      const datedFilter = [
-        `and(completed_at.gte.${range.start},completed_at.lt.${range.end})`,
-        `and(date_report_completed.gte.${range.startDate},date_report_completed.lt.${range.endDate})`
-      ].join(',')
-      if (includeUndated) {
-        query = query.or(`${datedFilter},and(completed_at.is.null,date_report_completed.is.null)`)
-      } else {
-        query = query.or(datedFilter)
-      }
-    }
-    if (grantCallId) query = query.eq('grant_call_id', grantCallId)
-
-    const { data: projects, error } = await query.order('completed_at', {
-      ascending: false,
-      nullsFirst: false
-    })
-    if (error) throw error
-
-    // Keep only rows whose effective Project Completion Date falls in the selected period
-    // (completed_at wins over date_report_completed when both exist and differ).
-    const inRange = (projects || []).filter((p: any) => {
+    // Filter strictly by effective Project Completion Date in application code.
+    // Prefer completed_at; fall back to date_report_completed for legacy rows.
+    const inRange = projects.filter((p: any) => {
       const effective = resolveProjectCompletionDate(p.completed_at, p.date_report_completed)
-      if (!range) return true
+      if (!range) {
+        if (includeUndated) return true
+        return !!effective
+      }
       if (!effective) return includeUndated
       return effective >= range.start && effective < range.end
     })
@@ -134,14 +128,21 @@ export async function GET(req: Request) {
       }
     })
 
-    // Prefer sorting by effective project completion date (newest first).
     rows.sort((a, b) => {
       const aT = a.project_completion_date ? Date.parse(a.project_completion_date) : 0
       const bT = b.project_completion_date ? Date.parse(b.project_completion_date) : 0
       return bT - aT
     })
 
-    return NextResponse.json({ rows })
+    return NextResponse.json({
+      rows,
+      meta: {
+        total_completed: projects.length,
+        matched: rows.length,
+        range,
+        include_undated: includeUndated
+      }
+    })
   } catch (e) {
     console.error('[data-archive/completed] error', e)
     return NextResponse.json({ error: 'Failed to load completed projects' }, { status: 500 })

--- a/src/app/api/data-archive/completed/route.ts
+++ b/src/app/api/data-archive/completed/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { getSupabaseRouteClient } from '@/lib/supabaseRouteClient'
 import { requirePermission } from '@/lib/requirePermission'
 import { collectArchiveFiles, type ArchiveProjectRow } from '@/lib/dataArchive'
+import { resolveProjectCompletionDate } from '@/lib/projectStatus'
 
 const PROJECT_SELECT = `
   id,
@@ -9,6 +10,7 @@ const PROJECT_SELECT = `
   grant_serial_id,
   state,
   completed_at,
+  date_report_completed,
   file_key,
   approval_file_key,
   mou_id,
@@ -20,13 +22,15 @@ const PROJECT_SELECT = `
 `
 
 /** Resolve month=YYYY-MM or from/to (inclusive dates) into an ISO [start, end) range. */
-function resolveRange(url: URL): { start: string; end: string } | null {
+function resolveRange(url: URL): { start: string; end: string; startDate: string; endDate: string } | null {
   const month = url.searchParams.get('month')
   if (month && /^\d{4}-\d{2}$/.test(month)) {
     const [y, m] = month.split('-').map(Number)
     const start = new Date(Date.UTC(y, m - 1, 1))
     const end = new Date(Date.UTC(y, m, 1))
-    return { start: start.toISOString(), end: end.toISOString() }
+    const startDate = start.toISOString().slice(0, 10)
+    const endDate = end.toISOString().slice(0, 10)
+    return { start: start.toISOString(), end: end.toISOString(), startDate, endDate }
   }
   const from = url.searchParams.get('from')
   const to = url.searchParams.get('to')
@@ -35,10 +39,20 @@ function resolveRange(url: URL): { start: string; end: string } | null {
     const endExclusive = new Date(`${to}T00:00:00.000Z`)
     endExclusive.setUTCDate(endExclusive.getUTCDate() + 1)
     if (!isNaN(start.getTime()) && !isNaN(endExclusive.getTime())) {
-      return { start: start.toISOString(), end: endExclusive.toISOString() }
+      return {
+        start: start.toISOString(),
+        end: endExclusive.toISOString(),
+        startDate: from,
+        endDate: endExclusive.toISOString().slice(0, 10)
+      }
     }
   }
   return null
+}
+
+/** Full grant call name, falling back to full donor name (never short abbreviations). */
+function grantNameLabel(p: any): string | null {
+  return p.grant_calls?.name || p.donors?.name || null
 }
 
 export async function GET(req: Request) {
@@ -50,7 +64,6 @@ export async function GET(req: Request) {
     const url = new URL(req.url)
     const range = resolveRange(url)
     const includeUndated = url.searchParams.get('include_undated') === 'true'
-    const donorId = url.searchParams.get('donor_id')
     const grantCallId = url.searchParams.get('grant_call_id')
 
     let query = supabase
@@ -59,15 +72,17 @@ export async function GET(req: Request) {
       .eq('status', 'completed')
 
     if (range) {
+      // Match either completed_at (new) or date_report_completed (legacy / report date).
+      const datedFilter = [
+        `and(completed_at.gte.${range.start},completed_at.lt.${range.end})`,
+        `and(date_report_completed.gte.${range.startDate},date_report_completed.lt.${range.endDate})`
+      ].join(',')
       if (includeUndated) {
-        query = query.or(
-          `and(completed_at.gte.${range.start},completed_at.lt.${range.end}),completed_at.is.null`
-        )
+        query = query.or(`${datedFilter},and(completed_at.is.null,date_report_completed.is.null)`)
       } else {
-        query = query.gte('completed_at', range.start).lt('completed_at', range.end)
+        query = query.or(datedFilter)
       }
     }
-    if (donorId) query = query.eq('donor_id', donorId)
     if (grantCallId) query = query.eq('grant_call_id', grantCallId)
 
     const { data: projects, error } = await query.order('completed_at', {
@@ -76,27 +91,37 @@ export async function GET(req: Request) {
     })
     if (error) throw error
 
-    const files = await collectArchiveFiles(supabase, (projects || []) as unknown as ArchiveProjectRow[])
+    // Keep only rows whose effective Project Completion Date falls in the selected period
+    // (completed_at wins over date_report_completed when both exist and differ).
+    const inRange = (projects || []).filter((p: any) => {
+      const effective = resolveProjectCompletionDate(p.completed_at, p.date_report_completed)
+      if (!range) return true
+      if (!effective) return includeUndated
+      return effective >= range.start && effective < range.end
+    })
 
-    const rows = (projects || []).map((p: any) => {
+    const files = await collectArchiveFiles(supabase, inRange as unknown as ArchiveProjectRow[])
+
+    const rows = inRange.map((p: any) => {
       const projectFiles = files[p.id] || []
       const has = (form: string, nameStartsWith: string) =>
         projectFiles.some((f) => f.form === form && f.name.startsWith(nameStartsWith) && !!f.storage_path)
       const count = (form: string) => projectFiles.filter((f) => f.form === form && !!f.storage_path).length
+      const projectCompletionDate = resolveProjectCompletionDate(p.completed_at, p.date_report_completed)
       return {
         id: p.id,
         grant_id: p.grant_id || null,
         grant_serial_id: p.grant_serial_id || null,
         state: p.state || null,
         completed_at: p.completed_at || null,
+        date_report_completed: p.date_report_completed || null,
+        project_completion_date: projectCompletionDate,
         err_code: p.emergency_rooms?.err_code || null,
         err_name: p.emergency_rooms?.name || null,
         donor_id: p.donors?.id || p.donor_id || null,
         donor_name: p.donors?.name || null,
-        donor_short_name: p.donors?.short_name || null,
         grant_call_id: p.grant_calls?.id || p.grant_call_id || null,
-        grant_call_name: p.grant_calls?.name || null,
-        grant_call_shortname: p.grant_calls?.shortname || null,
+        grant_name: grantNameLabel(p),
         files: {
           f1: has('F1', 'F1_workplan'),
           f2: has('F2', 'F2_approval'),
@@ -107,6 +132,13 @@ export async function GET(req: Request) {
           f5_count: count('F5')
         }
       }
+    })
+
+    // Prefer sorting by effective project completion date (newest first).
+    rows.sort((a, b) => {
+      const aT = a.project_completion_date ? Date.parse(a.project_completion_date) : 0
+      const bT = b.project_completion_date ? Date.parse(b.project_completion_date) : 0
+      return bT - aT
     })
 
     return NextResponse.json({ rows })

--- a/src/app/api/data-archive/export/route.ts
+++ b/src/app/api/data-archive/export/route.ts
@@ -4,6 +4,7 @@ import archiver from 'archiver'
 import { requirePermission } from '@/lib/requirePermission'
 import { getSupabaseAdmin } from '@/lib/supabaseAdmin'
 import { collectArchiveFiles, safeName, type ArchiveProjectRow } from '@/lib/dataArchive'
+import { resolveProjectCompletionDate } from '@/lib/projectStatus'
 
 export const runtime = 'nodejs'
 export const maxDuration = 300
@@ -56,6 +57,7 @@ export async function POST(req: Request) {
         state,
         status,
         completed_at,
+        date_report_completed,
         file_key,
         approval_file_key,
         mou_id,
@@ -90,14 +92,14 @@ export async function POST(req: Request) {
   // Fill the archive asynchronously while the response streams.
   ;(async () => {
     for (const p of projects) {
-      const donorLabel = p.donors?.short_name || p.donors?.name || 'Unknown-Donor'
-      const grantLabel = p.grant_calls?.shortname || p.grant_calls?.name || null
-      const grantFolder = safeName(grantLabel ? `${donorLabel} - ${grantLabel}` : donorLabel)
+      // Prefer full grant call name; fall back to full donor name (no short abbreviations).
+      const grantFolder = safeName(p.grant_calls?.name || p.donors?.name || 'Unknown-Grant')
       const serialFolder = safeName(p.grant_id || p.grant_serial_id || p.id)
-      const folder = `${monthFolder(p.completed_at)}/${grantFolder}/${serialFolder}`
+      const projectCompletionDate = resolveProjectCompletionDate(p.completed_at, p.date_report_completed)
+      const folder = `${monthFolder(projectCompletionDate)}/${grantFolder}/${serialFolder}`
 
       const manifestRows: string[] = [
-        ['form', 'file_name', 'original_storage_path', 'status', 'grant_id', 'err_code', 'err_name', 'state', 'completed_at', 'exported_at']
+        ['form', 'file_name', 'original_storage_path', 'status', 'grant_id', 'err_code', 'err_name', 'state', 'project_completion_date', 'exported_at']
           .join(',')
       ]
 
@@ -128,7 +130,7 @@ export async function POST(req: Request) {
             p.emergency_rooms?.err_code || '',
             p.emergency_rooms?.name || '',
             p.state || '',
-            p.completed_at || '',
+            projectCompletionDate || '',
             exportedAt
           ].map(csvCell).join(',')
         )

--- a/src/app/api/data-archive/export/route.ts
+++ b/src/app/api/data-archive/export/route.ts
@@ -39,7 +39,7 @@ export async function POST(req: Request) {
   }
   if (projectIds.length > MAX_PROJECTS_PER_EXPORT) {
     return NextResponse.json(
-      { error: `Too many projects in one export (max ${MAX_PROJECTS_PER_EXPORT}). Narrow the period or grant filter.` },
+      { error: `Too many projects in one export (max ${MAX_PROJECTS_PER_EXPORT}). Narrow the project completion date or grant name filter.` },
       { status: 400 }
     )
   }

--- a/src/app/api/overview/rollup/route.ts
+++ b/src/app/api/overview/rollup/route.ts
@@ -7,6 +7,7 @@ import {
   computePortalActualsFromProjectExpenses,
 } from '@/lib/f4ExpenseDisplay'
 import { normalizeStateName } from '@/lib/normalizeStateName'
+import { resolveProjectCompletionDate } from '@/lib/projectStatus'
 
 /** PostgREST `.in()` with hundreds of UUIDs can exceed URL limits and return empty data. */
 const SUPABASE_IN_BATCH = 80
@@ -241,7 +242,7 @@ export async function GET(request: Request) {
     // Build project filter (include more statuses to catch F5 projects and completed projects)
     let projectQuery = supabase
       .from('err_projects')
-      .select('id, state, grant_call_id, grant_grid_id, grant_id, grant_segment, emergency_rooms (id, name, name_ar, err_code), planned_activities, expenses, source, status, funding_status, mou_id, f4_status, f5_status, date, date_transfer, completed_at')
+      .select('id, state, grant_call_id, grant_grid_id, grant_id, grant_segment, emergency_rooms (id, name, name_ar, err_code), planned_activities, expenses, source, status, funding_status, mou_id, f4_status, f5_status, date, date_transfer, completed_at, date_report_completed')
       .in('status', ['approved', 'active', 'pending', 'completed'])
       .in('funding_status', ['committed', 'allocated'])
 
@@ -468,7 +469,7 @@ export async function GET(request: Request) {
         portal_f5_count: f5Agg.count, // For portal projects, all F5s are portal F5s
         last_f5_date: f5Agg.last,
         status: p.status || null,
-        completed_at: p.completed_at || null,
+        completed_at: resolveProjectCompletionDate(p.completed_at, p.date_report_completed),
         is_historical: false,
         f4_status,
         f5_status,

--- a/src/app/err-portal/data-archive/page.tsx
+++ b/src/app/err-portal/data-archive/page.tsx
@@ -19,14 +19,14 @@ interface ArchiveRow {
   grant_serial_id: string | null
   state: string | null
   completed_at: string | null
+  date_report_completed: string | null
+  project_completion_date: string | null
   err_code: string | null
   err_name: string | null
   donor_id: string | null
   donor_name: string | null
-  donor_short_name: string | null
   grant_call_id: string | null
-  grant_call_name: string | null
-  grant_call_shortname: string | null
+  grant_name: string | null
   files: {
     f1: boolean
     f2: boolean
@@ -80,7 +80,7 @@ export default function DataArchivePage() {
   const [fromDate, setFromDate] = useState<string>('')
   const [toDate, setToDate] = useState<string>('')
   const [includeUndated, setIncludeUndated] = useState(false)
-  const [donorFilter, setDonorFilter] = useState<string>('all')
+  const [grantFilter, setGrantFilter] = useState<string>('all')
 
   const [loading, setLoading] = useState(false)
   const [rows, setRows] = useState<ArchiveRow[]>([])
@@ -122,18 +122,23 @@ export default function DataArchivePage() {
     if (!permissionsLoading && canViewPage) loadRows()
   }, [permissionsLoading, canViewPage, loadRows])
 
-  const donorOptions = useMemo(() => {
+  const grantOptions = useMemo(() => {
     const map = new Map<string, string>()
     for (const r of rows) {
-      if (r.donor_id) map.set(r.donor_id, r.donor_short_name || r.donor_name || r.donor_id)
+      if (r.grant_call_id && r.grant_name) map.set(r.grant_call_id, r.grant_name)
+      else if (!r.grant_call_id && r.grant_name) map.set(`name:${r.grant_name}`, r.grant_name)
     }
     return Array.from(map.entries()).sort((a, b) => a[1].localeCompare(b[1]))
   }, [rows])
 
   const filteredRows = useMemo(() => {
-    if (donorFilter === 'all') return rows
-    return rows.filter((r) => r.donor_id === donorFilter)
-  }, [rows, donorFilter])
+    if (grantFilter === 'all') return rows
+    if (grantFilter.startsWith('name:')) {
+      const name = grantFilter.slice(5)
+      return rows.filter((r) => !r.grant_call_id && r.grant_name === name)
+    }
+    return rows.filter((r) => r.grant_call_id === grantFilter)
+  }, [rows, grantFilter])
 
   const allSelected = filteredRows.length > 0 && filteredRows.every((r) => selected.has(r.id))
 
@@ -204,14 +209,14 @@ export default function DataArchivePage() {
 
       <Card>
         <CardHeader className="pb-3">
-          <CardTitle className="text-base">Export period</CardTitle>
+          <CardTitle className="text-base">Export by project completion date</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="flex flex-wrap items-end gap-4">
             <div className="space-y-1.5">
-              <Label className="text-sm">Period</Label>
+              <Label className="text-sm">Project Completion Date</Label>
               <Select value={periodMode} onValueChange={(v) => setPeriodMode(v as PeriodMode)}>
-                <SelectTrigger className="h-9 w-40">
+                <SelectTrigger className="h-9 w-44">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -240,14 +245,14 @@ export default function DataArchivePage() {
               </>
             )}
             <div className="space-y-1.5">
-              <Label className="text-sm">Backdonor grant</Label>
-              <Select value={donorFilter} onValueChange={setDonorFilter}>
-                <SelectTrigger className="h-9 w-52">
+              <Label className="text-sm">Grant name</Label>
+              <Select value={grantFilter} onValueChange={setGrantFilter}>
+                <SelectTrigger className="h-9 w-64">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="all">All donors</SelectItem>
-                  {donorOptions.map(([id, label]) => (
+                  <SelectItem value="all">All grants</SelectItem>
+                  {grantOptions.map(([id, label]) => (
                     <SelectItem key={id} value={id}>{label}</SelectItem>
                   ))}
                 </SelectContent>
@@ -274,15 +279,15 @@ export default function DataArchivePage() {
           </div>
           <p className="text-xs text-muted-foreground mt-3">
             Only microgrants marked as completed are available for export. Files are organized as
-            Month (YYYY-MM) &gt; Backdonor Grant &gt; Serial Number, with a manifest recording original
-            file locations and completion metadata in each folder.
+            Month (YYYY-MM) &gt; Grant Name &gt; Serial Number, with a manifest recording original
+            file locations and project completion date in each folder.
           </p>
         </CardContent>
       </Card>
 
       <Card>
         <CardHeader className="pb-3">
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between gap-4 flex-wrap">
             <CardTitle className="text-base">
               Completed microgrants
               <span className="ml-2 text-sm font-normal text-muted-foreground">
@@ -291,24 +296,30 @@ export default function DataArchivePage() {
               </span>
             </CardTitle>
             {canDownload && (
-              <div className="flex items-center gap-2">
-                <Button
-                  size="sm"
-                  variant="outline"
-                  disabled={exporting || selected.size === 0}
-                  onClick={() => runExport(Array.from(selected))}
-                >
-                  <Download className={cn('h-4 w-4 mr-2', exporting && 'animate-pulse')} />
-                  Export selected
-                </Button>
-                <Button
-                  size="sm"
-                  disabled={exporting || filteredRows.length === 0}
-                  onClick={() => runExport(filteredRows.map((r) => r.id))}
-                >
-                  <Download className={cn('h-4 w-4 mr-2', exporting && 'animate-pulse')} />
-                  {exporting ? 'Preparing zip…' : 'Export all'}
-                </Button>
+              <div className="flex flex-col items-end gap-1.5">
+                <div className="flex items-center gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={exporting || selected.size === 0}
+                    onClick={() => runExport(Array.from(selected))}
+                  >
+                    <Download className={cn('h-4 w-4 mr-2', exporting && 'animate-pulse')} />
+                    Export selected
+                  </Button>
+                  <Button
+                    size="sm"
+                    disabled={exporting || filteredRows.length === 0}
+                    onClick={() => runExport(filteredRows.map((r) => r.id))}
+                  >
+                    <Download className={cn('h-4 w-4 mr-2', exporting && 'animate-pulse')} />
+                    {exporting ? 'Preparing zip…' : 'Export all'}
+                  </Button>
+                </div>
+                <p className="text-xs text-muted-foreground max-w-md text-right">
+                  Large exports (for example hundreds of projects) can take a long time while the system
+                  retrieves each original source file. Please keep this tab open until the download finishes.
+                </p>
               </div>
             )}
           </div>
@@ -326,10 +337,10 @@ export default function DataArchivePage() {
                       <Checkbox checked={allSelected} onCheckedChange={toggleAll} aria-label="Select all" />
                     </TableHead>
                     <TableHead className="whitespace-nowrap">Serial Number</TableHead>
-                    <TableHead className="whitespace-nowrap">Backdonor Grant</TableHead>
+                    <TableHead className="whitespace-nowrap">Grant name</TableHead>
                     <TableHead className="whitespace-nowrap">ERR</TableHead>
                     <TableHead className="whitespace-nowrap">State</TableHead>
-                    <TableHead className="whitespace-nowrap">Completed</TableHead>
+                    <TableHead className="whitespace-nowrap">Project Completion Date</TableHead>
                     <TableHead className="whitespace-nowrap">Files</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -337,7 +348,7 @@ export default function DataArchivePage() {
                   {filteredRows.length === 0 ? (
                     <TableRow>
                       <TableCell colSpan={7} className="text-center text-muted-foreground py-6">
-                        No completed microgrants found for this period.
+                        No completed microgrants found for this project completion date.
                       </TableCell>
                     </TableRow>
                   ) : (
@@ -353,16 +364,16 @@ export default function DataArchivePage() {
                         <TableCell className="font-medium whitespace-nowrap">
                           {r.grant_id || r.grant_serial_id || '—'}
                         </TableCell>
-                        <TableCell className="whitespace-nowrap">
-                          {r.donor_short_name || r.donor_name || '—'}
-                          {r.grant_call_shortname || r.grant_call_name ? (
-                            <span className="text-muted-foreground"> · {r.grant_call_shortname || r.grant_call_name}</span>
-                          ) : null}
+                        <TableCell className="whitespace-nowrap" title={r.grant_name || undefined}>
+                          {r.grant_name || '—'}
                         </TableCell>
                         <TableCell className="whitespace-nowrap">{r.err_code || r.err_name || '—'}</TableCell>
                         <TableCell className="whitespace-nowrap">{r.state || '—'}</TableCell>
-                        <TableCell className="whitespace-nowrap" title={r.completed_at || 'No completion date recorded'}>
-                          {formatDate(r.completed_at)}
+                        <TableCell
+                          className="whitespace-nowrap"
+                          title={r.project_completion_date || 'No completion date recorded'}
+                        >
+                          {formatDate(r.project_completion_date)}
                         </TableCell>
                         <TableCell>
                           <div className="flex flex-wrap gap-1">

--- a/src/app/err-portal/data-archive/page.tsx
+++ b/src/app/err-portal/data-archive/page.tsx
@@ -38,13 +38,52 @@ interface ArchiveRow {
   }
 }
 
-type PeriodMode = 'month' | 'range' | 'all'
+type DateFilterMode = 'month' | 'range' | 'all'
 
 function previousMonth(): string {
   const d = new Date()
   d.setUTCDate(1)
   d.setUTCMonth(d.getUTCMonth() - 1)
   return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`
+}
+
+/** Inclusive calendar [start, end) in UTC ISO, matching the API. */
+function resolveCompletionRange(
+  mode: DateFilterMode,
+  month: string,
+  fromDate: string,
+  toDate: string
+): { start: string; end: string } | null {
+  if (mode === 'all') return null
+  if (mode === 'month' && /^\d{4}-\d{2}$/.test(month)) {
+    const [y, m] = month.split('-').map(Number)
+    const start = new Date(Date.UTC(y, m - 1, 1))
+    const end = new Date(Date.UTC(y, m, 1))
+    return { start: start.toISOString(), end: end.toISOString() }
+  }
+  if (mode === 'range' && fromDate && toDate) {
+    const start = new Date(`${fromDate}T00:00:00.000Z`)
+    const endExclusive = new Date(`${toDate}T00:00:00.000Z`)
+    endExclusive.setUTCDate(endExclusive.getUTCDate() + 1)
+    if (!isNaN(start.getTime()) && !isNaN(endExclusive.getTime())) {
+      return { start: start.toISOString(), end: endExclusive.toISOString() }
+    }
+  }
+  return null
+}
+
+/** Format YYYY-MM-DD / ISO without shifting calendar day across timezones. */
+function formatCompletionDate(iso: string | null) {
+  if (!iso) return '—'
+  const day = iso.slice(0, 10)
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) return '—'
+  const [y, m, d] = day.split('-').map(Number)
+  return new Date(Date.UTC(y, m - 1, d)).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC'
+  })
 }
 
 function FileBadge({ label, present }: { label: string; present: boolean }) {
@@ -75,7 +114,7 @@ export default function DataArchivePage() {
     }
   }, [permissionsLoading, canViewPage, router])
 
-  const [periodMode, setPeriodMode] = useState<PeriodMode>('month')
+  const [dateFilterMode, setDateFilterMode] = useState<DateFilterMode>('month')
   const [month, setMonth] = useState<string>(previousMonth())
   const [fromDate, setFromDate] = useState<string>('')
   const [toDate, setToDate] = useState<string>('')
@@ -88,19 +127,28 @@ export default function DataArchivePage() {
   const [exporting, setExporting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  const completionRange = useMemo(
+    () => resolveCompletionRange(dateFilterMode, month, fromDate, toDate),
+    [dateFilterMode, month, fromDate, toDate]
+  )
+
   const loadRows = useCallback(async () => {
-    if (periodMode === 'month' && !month) return
-    if (periodMode === 'range' && (!fromDate || !toDate)) return
+    if (dateFilterMode === 'month' && !month) return
+    if (dateFilterMode === 'range' && (!fromDate || !toDate)) {
+      setRows([])
+      setSelected(new Set())
+      return
+    }
     setLoading(true)
     setError(null)
     try {
       const params = new URLSearchParams()
-      if (periodMode === 'month') params.set('month', month)
-      if (periodMode === 'range') {
+      if (dateFilterMode === 'month') params.set('month', month)
+      if (dateFilterMode === 'range') {
         params.set('from', fromDate)
         params.set('to', toDate)
       }
-      if (periodMode !== 'all' && includeUndated) params.set('include_undated', 'true')
+      if (dateFilterMode !== 'all' && includeUndated) params.set('include_undated', 'true')
       const res = await fetch(`/api/data-archive/completed?${params.toString()}`)
       if (!res.ok) {
         const j = await res.json().catch(() => ({}))
@@ -116,7 +164,7 @@ export default function DataArchivePage() {
     } finally {
       setLoading(false)
     }
-  }, [periodMode, month, fromDate, toDate, includeUndated])
+  }, [dateFilterMode, month, fromDate, toDate, includeUndated])
 
   useEffect(() => {
     if (!permissionsLoading && canViewPage) loadRows()
@@ -132,13 +180,23 @@ export default function DataArchivePage() {
   }, [rows])
 
   const filteredRows = useMemo(() => {
-    if (grantFilter === 'all') return rows
+    // Defense-in-depth: keep only rows whose Project Completion Date is in the selected window.
+    let list = rows.filter((r) => {
+      const effective = r.project_completion_date
+      if (!completionRange) {
+        if (dateFilterMode === 'all') return includeUndated ? true : !!effective
+        return true
+      }
+      if (!effective) return includeUndated
+      return effective >= completionRange.start && effective < completionRange.end
+    })
+    if (grantFilter === 'all') return list
     if (grantFilter.startsWith('name:')) {
       const name = grantFilter.slice(5)
-      return rows.filter((r) => !r.grant_call_id && r.grant_name === name)
+      return list.filter((r) => !r.grant_call_id && r.grant_name === name)
     }
-    return rows.filter((r) => r.grant_call_id === grantFilter)
-  }, [rows, grantFilter])
+    return list.filter((r) => r.grant_call_id === grantFilter)
+  }, [rows, grantFilter, completionRange, dateFilterMode, includeUndated])
 
   const allSelected = filteredRows.length > 0 && filteredRows.every((r) => selected.has(r.id))
 
@@ -193,9 +251,6 @@ export default function DataArchivePage() {
     }
   }
 
-  const formatDate = (iso: string | null) =>
-    iso ? new Date(iso).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' }) : '—'
-
   if (permissionsLoading || !canViewPage) return null
 
   return (
@@ -209,37 +264,37 @@ export default function DataArchivePage() {
 
       <Card>
         <CardHeader className="pb-3">
-          <CardTitle className="text-base">Export by project completion date</CardTitle>
+          <CardTitle className="text-base">Filter by Project Completion Date</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="flex flex-wrap items-end gap-4">
             <div className="space-y-1.5">
               <Label className="text-sm">Project Completion Date</Label>
-              <Select value={periodMode} onValueChange={(v) => setPeriodMode(v as PeriodMode)}>
-                <SelectTrigger className="h-9 w-44">
+              <Select value={dateFilterMode} onValueChange={(v) => setDateFilterMode(v as DateFilterMode)}>
+                <SelectTrigger className="h-9 w-52">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="month">Month</SelectItem>
-                  <SelectItem value="range">Custom range</SelectItem>
-                  <SelectItem value="all">All completed</SelectItem>
+                  <SelectItem value="month">By month</SelectItem>
+                  <SelectItem value="range">Custom date range</SelectItem>
+                  <SelectItem value="all">All completion dates</SelectItem>
                 </SelectContent>
               </Select>
             </div>
-            {periodMode === 'month' && (
+            {dateFilterMode === 'month' && (
               <div className="space-y-1.5">
-                <Label className="text-sm">Month</Label>
+                <Label className="text-sm">Completion month</Label>
                 <Input type="month" className="h-9 w-44" value={month} onChange={(e) => setMonth(e.target.value)} />
               </div>
             )}
-            {periodMode === 'range' && (
+            {dateFilterMode === 'range' && (
               <>
                 <div className="space-y-1.5">
-                  <Label className="text-sm">From</Label>
+                  <Label className="text-sm">Completion date from</Label>
                   <Input type="date" className="h-9 w-40" value={fromDate} onChange={(e) => setFromDate(e.target.value)} />
                 </div>
                 <div className="space-y-1.5">
-                  <Label className="text-sm">To</Label>
+                  <Label className="text-sm">Completion date to</Label>
                   <Input type="date" className="h-9 w-40" value={toDate} onChange={(e) => setToDate(e.target.value)} />
                 </div>
               </>
@@ -258,7 +313,7 @@ export default function DataArchivePage() {
                 </SelectContent>
               </Select>
             </div>
-            {periodMode !== 'all' && (
+            {dateFilterMode !== 'all' && (
               <div className="flex items-center gap-2 pb-2">
                 <Checkbox
                   id="include-undated"
@@ -278,9 +333,8 @@ export default function DataArchivePage() {
             </div>
           </div>
           <p className="text-xs text-muted-foreground mt-3">
-            Only microgrants marked as completed are available for export. Files are organized as
-            Month (YYYY-MM) &gt; Grant Name &gt; Serial Number, with a manifest recording original
-            file locations and project completion date in each folder.
+            Only microgrants marked as completed are listed, filtered by Project Completion Date.
+            Exports are organized as Completion month (YYYY-MM) &gt; Grant Name &gt; Serial Number.
           </p>
         </CardContent>
       </Card>
@@ -348,7 +402,7 @@ export default function DataArchivePage() {
                   {filteredRows.length === 0 ? (
                     <TableRow>
                       <TableCell colSpan={7} className="text-center text-muted-foreground py-6">
-                        No completed microgrants found for this project completion date.
+                        No completed microgrants found for this Project Completion Date.
                       </TableCell>
                     </TableRow>
                   ) : (
@@ -373,7 +427,7 @@ export default function DataArchivePage() {
                           className="whitespace-nowrap"
                           title={r.project_completion_date || 'No completion date recorded'}
                         >
-                          {formatDate(r.project_completion_date)}
+                          {formatCompletionDate(r.project_completion_date)}
                         </TableCell>
                         <TableCell>
                           <div className="flex flex-wrap gap-1">

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -1588,6 +1588,7 @@ export type Database = {
           date: string | null
           date_report_completed: string | null
           date_transfer: string | null
+          completed_at: string | null
           donor_id: string | null
           emergency_room_id: string | null
           end_date: string | null
@@ -1647,6 +1648,7 @@ export type Database = {
           date?: string | null
           date_report_completed?: string | null
           date_transfer?: string | null
+          completed_at?: string | null
           donor_id?: string | null
           emergency_room_id?: string | null
           end_date?: string | null
@@ -1706,6 +1708,7 @@ export type Database = {
           date?: string | null
           date_report_completed?: string | null
           date_transfer?: string | null
+          completed_at?: string | null
           donor_id?: string | null
           emergency_room_id?: string | null
           end_date?: string | null

--- a/src/lib/projectStatus.ts
+++ b/src/lib/projectStatus.ts
@@ -27,6 +27,7 @@ export type ApplyReportingStatusResult =
       ok: true
       applied: ReportingStatusChanges & {
         status?: 'completed'
+        completed_at?: string | null
         date_report_completed?: string | null
       }
     }
@@ -79,7 +80,7 @@ export async function applyReportingStatusUpdates(
 
   const { data: project, error: fetchError } = await supabase
     .from('err_projects')
-    .select('status, f4_status, f5_status, date_report_completed')
+    .select('status, f4_status, f5_status, date_report_completed, completed_at')
     .eq('id', projectId)
     .single()
 
@@ -99,6 +100,10 @@ export async function applyReportingStatusUpdates(
 
   if (shouldAutoCompleteProject(project.status, nextF4, nextF5)) {
     update.status = 'completed'
+    // Data Archive + Project Management rely on completed_at; keep any existing stamp.
+    if (!project.completed_at) {
+      update.completed_at = new Date().toISOString()
+    }
   }
 
   if (bothCompleted) {
@@ -123,7 +128,26 @@ export async function applyReportingStatusUpdates(
     ok: true,
     applied: update as ReportingStatusChanges & {
       status?: 'completed'
+      completed_at?: string | null
       date_report_completed?: string | null
     },
   }
+}
+
+/**
+ * Effective project completion timestamp for archive filtering and display.
+ * Prefers completed_at (when marked completed); falls back to date_report_completed for legacy rows.
+ */
+export function resolveProjectCompletionDate(
+  completedAt: string | null | undefined,
+  dateReportCompleted: string | null | undefined
+): string | null {
+  if (completedAt) return completedAt
+  if (!dateReportCompleted) return null
+  const raw = String(dateReportCompleted).trim()
+  if (!raw) return null
+  // date_report_completed is stored as YYYY-MM-DD; treat as UTC midnight for month bucketing.
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return `${raw}T00:00:00.000Z`
+  const d = new Date(raw)
+  return isNaN(d.getTime()) ? null : d.toISOString()
 }


### PR DESCRIPTION
## Summary
- Rename Period → Project Completion Date; show full grant names
- Fix completion dates (stamp completed_at on auto-complete; coalesce with date_report_completed)
- Harden completion-date filtering so only the selected window is shown
- Warn that large zip exports can take a long time

## Test plan
- [ ] Data Archive month filter (e.g. 2026-07) shows only that month
- [ ] Project Completion Date column populated for legacy completed projects
- [ ] Grant name column shows full grant call names
